### PR TITLE
add Http.send and surrounding types and tests

### DIFF
--- a/src/Testable.elm
+++ b/src/Testable.elm
@@ -46,8 +46,8 @@ cmd testableEffects =
 task : Testable.Task.Task error success -> Task.Task error success
 task testableTask =
     case testableTask of
-        Internal.HttpTask request mapResponse ->
-            Http.send Http.defaultSettings request
+        Internal.HttpTask request settings mapResponse ->
+            Http.send settings request
                 |> Task.toResult
                 |> Task.map mapResponse
                 |> (flip Task.andThen) taskResult

--- a/src/Testable/EffectsLog.elm
+++ b/src/Testable/EffectsLog.elm
@@ -53,7 +53,7 @@ insert effects (EffectsLog log) =
         Internal.None ->
             ( EffectsLog log, [] )
 
-        Internal.TaskCmd (Internal.HttpTask request mapResponse) ->
+        Internal.TaskCmd (Internal.HttpTask request settings mapResponse) ->
             ( EffectsLog { log | http = Dict.insert request (mapResponse >> unsafeFromResult) log.http }
             , []
             )

--- a/src/Testable/Internal.elm
+++ b/src/Testable/Internal.elm
@@ -11,7 +11,7 @@ type Cmd msg
 
 
 type Task error success
-    = HttpTask Http.Request (Result Http.RawError Http.Response -> TaskResult error success)
+    = HttpTask Http.Request Http.Settings (Result Http.RawError Http.Response -> TaskResult error success)
     | ImmediateTask (TaskResult error success)
     | SleepTask Time (TaskResult error success)
 

--- a/src/Testable/Task.elm
+++ b/src/Testable/Task.elm
@@ -145,8 +145,8 @@ toResult source =
 transform : (TaskResult x a -> TaskResult y b) -> Task x a -> Task y b
 transform tx source =
     case source of
-        Internal.HttpTask request mapResponse ->
-            Internal.HttpTask request (mapResponse >> tx)
+        Internal.HttpTask request settings mapResponse ->
+            Internal.HttpTask request settings (mapResponse >> tx)
 
         Internal.ImmediateTask result ->
             Internal.ImmediateTask (result |> tx)


### PR DESCRIPTION
Hi!

In this PR I've added `Http.send` and updated the things affected by that change to the best of my ability.
- `Internal.HttpTask` now accepts an `Http.Settings` argument in addition to `request` and `mapResponse`
- Basic request functions now add `Http.defaultSettings` explicitly when creating an `Internal.HttpTask`
- `send`, `Settings`, and `defaultSettings` are exposed from `Testable.Http`
- I added 2 tests to ensure that a component using `send` behaved the same as the `loadingComponent` using `getString`

The only odd thing I encountered is that if one exposes a union type as a type alias Elm won't allow exposing each member of the union type as well, so in the tests you'll notice an `import Http as ElmHttp` in order to access the members of `Http.Value`.

Thanks! Looking forward to your feedback and to integrating this into HttpBuilder with `HttpBuilder.sendAsTestable` or something like that!
