### PR TITLE
add Http.send and surrounding types and tests

### DIFF
--- a/src/Testable.elm
+++ b/src/Testable.elm
@@ -46,8 +46,8 @@ cmd testableEffects =
 task : Testable.Task.Task error success -> Task.Task error success
 task testableTask =
     case testableTask of
-        Internal.HttpTask request mapResponse ->
-            Http.send Http.defaultSettings request
+        Internal.HttpTask request settings mapResponse ->
+            Http.send settings request
                 |> Task.toResult
                 |> Task.map mapResponse
                 |> (flip Task.andThen) taskResult

--- a/src/Testable.elm
+++ b/src/Testable.elm
@@ -47,10 +47,17 @@ task : Testable.Task.Task error success -> Task.Task error success
 task testableTask =
     case testableTask of
         Internal.HttpTask settings request mapResponse ->
-            Http.send settings request
-                |> Task.toResult
-                |> Task.map mapResponse
-                |> (flip Task.andThen) taskResult
+            let
+                httpSettings =
+                    { settings
+                        | onStart = Maybe.map task settings.onStart
+                        , onProgress = Maybe.map ((<<) task) settings.onProgress
+                    }
+            in
+                Http.send httpSettings request
+                    |> Task.toResult
+                    |> Task.map mapResponse
+                    |> (flip Task.andThen) taskResult
 
         Internal.ImmediateTask result ->
             taskResult result

--- a/src/Testable.elm
+++ b/src/Testable.elm
@@ -46,7 +46,7 @@ cmd testableEffects =
 task : Testable.Task.Task error success -> Task.Task error success
 task testableTask =
     case testableTask of
-        Internal.HttpTask request settings mapResponse ->
+        Internal.HttpTask settings request mapResponse ->
             Http.send settings request
                 |> Task.toResult
                 |> Task.map mapResponse

--- a/src/Testable/EffectsLog.elm
+++ b/src/Testable/EffectsLog.elm
@@ -53,7 +53,7 @@ insert effects (EffectsLog log) =
         Internal.None ->
             ( EffectsLog log, [] )
 
-        Internal.TaskCmd (Internal.HttpTask request settings mapResponse) ->
+        Internal.TaskCmd (Internal.HttpTask settings request mapResponse) ->
             ( EffectsLog { log | http = Dict.insert request (mapResponse >> unsafeFromResult) log.http }
             , []
             )

--- a/src/Testable/EffectsLog.elm
+++ b/src/Testable/EffectsLog.elm
@@ -53,7 +53,7 @@ insert effects (EffectsLog log) =
         Internal.None ->
             ( EffectsLog log, [] )
 
-        Internal.TaskCmd (Internal.HttpTask request mapResponse) ->
+        Internal.TaskCmd (Internal.HttpTask request settings mapResponse) ->
             ( EffectsLog { log | http = Dict.insert request (mapResponse >> unsafeFromResult) log.http }
             , []
             )

--- a/src/Testable/Http.elm
+++ b/src/Testable/Http.elm
@@ -4,9 +4,6 @@ module Testable.Http exposing (url, getString, get, post, Error, empty, string, 
 `Testable.Http` is a replacement for the standard `Http` module.  You can use it
 to create components that can be tested with `Testable.TestContext`.
 
-# Helpers
-@docs getRequest, ok, serverError
-
 # Encoding and Decoding
 @docs url
 
@@ -17,10 +14,13 @@ to create components that can be tested with `Testable.TestContext`.
 @docs empty, string
 
 # Arbitrary Requests
-@docs Request, Settings, send, defaultSettings
+@docs send, Request, Settings, defaultSettings
 
 # Responses
 @docs Response, RawError
+
+# Helpers
+@docs getRequest, ok, serverError
 -}
 
 import Dict
@@ -153,15 +153,6 @@ post decoder url requestBody =
             )
 
 
-{-| Send a request exactly how you want it. The Settings argument lets you
-configure things like timeouts and progress monitoring. The Request argument
-defines all the information that will actually be sent along to a server.
--}
-send : Settings -> Request -> Task RawError Response
-send settings request =
-    Internal.HttpTask settings request Internal.resultFromResult
-
-
 {-| The kinds of errors you typically want in practice. When you get a
 response but its status is not in the 200 range, it will trigger a
 `BadResponse`. When you try to decode JSON but something goes wrong,
@@ -210,6 +201,15 @@ string =
 -- Arbitrary Requests
 
 
+{-| Send a request exactly how you want it. The Settings argument lets you
+configure things like timeouts and progress monitoring. The Request argument
+defines all the information that will actually be sent along to a server.
+-}
+send : Settings -> Request -> Task RawError Response
+send settings request =
+    Internal.HttpTask settings request Internal.resultFromResult
+
+
 {-| Fully specify the request you want to send. For example, if you want to
 send a request between domains (CORS request) you will need to specify some
 headers manually.
@@ -256,17 +256,6 @@ defaultSettings =
     Http.defaultSettings
 
 
-{-| A convenient way to make a `Request` corresponding to the request made by `get`
--}
-getRequest : String -> Request
-getRequest url =
-    { verb = "GET"
-    , headers = []
-    , url = url
-    , body = Http.empty
-    }
-
-
 
 -- Responses
 
@@ -300,6 +289,21 @@ want.
 -}
 type alias RawError =
     Http.RawError
+
+
+
+-- Helpers
+
+
+{-| A convenient way to make a `Request` corresponding to the request made by `get`
+-}
+getRequest : String -> Request
+getRequest url =
+    { verb = "GET"
+    , headers = []
+    , url = url
+    , body = Http.empty
+    }
 
 
 {-| A convenient way to create a 200 OK repsonse

--- a/src/Testable/Http.elm
+++ b/src/Testable/Http.elm
@@ -81,9 +81,8 @@ getString url =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask
+        Internal.HttpTask (Http.defaultSettings)
             (getRequest url)
-            (Http.defaultSettings)
             (Result.formatError rawErrorError
                 >> (flip Result.andThen) decodeResponse
                 >> Internal.resultFromResult
@@ -111,9 +110,8 @@ get decoder url =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask
+        Internal.HttpTask (Http.defaultSettings)
             (getRequest url)
-            (Http.defaultSettings)
             (Result.formatError rawErrorError
                 >> (flip Result.andThen) decodeResponse
                 >> Internal.resultFromResult
@@ -143,13 +141,12 @@ post decoder url requestBody =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask
+        Internal.HttpTask (Http.defaultSettings)
             { verb = "POST"
             , headers = []
             , url = url
             , body = requestBody
             }
-            (Http.defaultSettings)
             (Result.formatError rawErrorError
                 >> (flip Result.andThen) decodeResponse
                 >> Internal.resultFromResult
@@ -162,7 +159,7 @@ defines all the information that will actually be sent along to a server.
 -}
 send : Settings -> Request -> Task RawError Response
 send settings request =
-    Internal.HttpTask request settings Internal.resultFromResult
+    Internal.HttpTask settings request Internal.resultFromResult
 
 
 {-| The kinds of errors you typically want in practice. When you get a

--- a/src/Testable/Http.elm
+++ b/src/Testable/Http.elm
@@ -28,6 +28,7 @@ import Http
 import Json.Decode as Decode exposing (Decoder)
 import Testable.Task as Task exposing (Task)
 import Testable.Internal as Internal
+import Time exposing (Time)
 
 
 -- Encoding and Decoding
@@ -81,7 +82,7 @@ getString url =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask (Http.defaultSettings)
+        Internal.HttpTask defaultSettings
             (getRequest url)
             (Result.formatError rawErrorError
                 >> (flip Result.andThen) decodeResponse
@@ -110,7 +111,7 @@ get decoder url =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask (Http.defaultSettings)
+        Internal.HttpTask defaultSettings
             (getRequest url)
             (Result.formatError rawErrorError
                 >> (flip Result.andThen) decodeResponse
@@ -141,7 +142,7 @@ post decoder url requestBody =
                 Http.Blob _ ->
                     Err <| Http.UnexpectedPayload "Not Implemented: Decoding of Http.Blob response body"
     in
-        Internal.HttpTask (Http.defaultSettings)
+        Internal.HttpTask defaultSettings
             { verb = "POST"
             , headers = []
             , url = url
@@ -240,7 +241,7 @@ type alias Request =
     you can influence what kind of `Value` you get in the `Response`.
 -}
 type alias Settings =
-    Http.Settings
+    Internal.Settings
 
 
 {-| The default settings used by `get` and `post`.
@@ -253,7 +254,12 @@ type alias Settings =
 -}
 defaultSettings : Settings
 defaultSettings =
-    Http.defaultSettings
+    { timeout = 0
+    , onStart = Nothing
+    , onProgress = Nothing
+    , desiredResponseType = Nothing
+    , withCredentials = False
+    }
 
 
 

--- a/src/Testable/Internal.elm
+++ b/src/Testable/Internal.elm
@@ -11,7 +11,7 @@ type Cmd msg
 
 
 type Task error success
-    = HttpTask Http.Request (Result Http.RawError Http.Response -> TaskResult error success)
+    = HttpTask Http.Request Http.Settings (Result Http.RawError Http.Response -> TaskResult error success)
     | ImmediateTask (TaskResult error success)
     | SleepTask Time (TaskResult error success)
 

--- a/src/Testable/Internal.elm
+++ b/src/Testable/Internal.elm
@@ -10,8 +10,17 @@ type Cmd msg
     | Batch (List (Cmd msg))
 
 
+type alias Settings =
+    { timeout : Time
+    , onStart : Maybe (Task () ())
+    , onProgress : Maybe (Maybe { loaded : Int, total : Int } -> Task () ())
+    , desiredResponseType : Maybe String
+    , withCredentials : Bool
+    }
+
+
 type Task error success
-    = HttpTask Http.Settings Http.Request (Result Http.RawError Http.Response -> TaskResult error success)
+    = HttpTask Settings Http.Request (Result Http.RawError Http.Response -> TaskResult error success)
     | ImmediateTask (TaskResult error success)
     | SleepTask Time (TaskResult error success)
 

--- a/src/Testable/Internal.elm
+++ b/src/Testable/Internal.elm
@@ -11,7 +11,7 @@ type Cmd msg
 
 
 type Task error success
-    = HttpTask Http.Request Http.Settings (Result Http.RawError Http.Response -> TaskResult error success)
+    = HttpTask Http.Settings Http.Request (Result Http.RawError Http.Response -> TaskResult error success)
     | ImmediateTask (TaskResult error success)
     | SleepTask Time (TaskResult error success)
 

--- a/src/Testable/Task.elm
+++ b/src/Testable/Task.elm
@@ -145,8 +145,8 @@ toResult source =
 transform : (TaskResult x a -> TaskResult y b) -> Task x a -> Task y b
 transform tx source =
     case source of
-        Internal.HttpTask request mapResponse ->
-            Internal.HttpTask request (mapResponse >> tx)
+        Internal.HttpTask request settings mapResponse ->
+            Internal.HttpTask request settings (mapResponse >> tx)
 
         Internal.ImmediateTask result ->
             Internal.ImmediateTask (result |> tx)

--- a/tests/Testable/EffectsLogTests.elm
+++ b/tests/Testable/EffectsLogTests.elm
@@ -13,7 +13,7 @@ type MyWrapper a
 
 httpGetMsg : String -> String -> EffectsLog msg -> Maybe ( EffectsLog msg, List msg )
 httpGetMsg url responseBody =
-    EffectsLog.httpMsg
+    EffectsLog.httpMsg Http.defaultSettings
         { verb = "GET"
         , headers = []
         , url = url

--- a/tests/TestableTests.elm
+++ b/tests/TestableTests.elm
@@ -7,7 +7,6 @@ import Testable.Cmd
 import Testable.Http as Http
 import Http as ElmHttp
 import Testable.Task as Task
-import Task as ElmTask
 import Time
 
 
@@ -60,7 +59,7 @@ type RawLoadingMsg
 componentWithSendSettings : Http.Settings
 componentWithSendSettings =
     { timeout = 500
-    , onStart = Just <| ElmTask.succeed ()
+    , onStart = Just <| Task.succeed ()
     , onProgress = Nothing
     , desiredResponseType = Just "text/plain"
     , withCredentials = True


### PR DESCRIPTION
This PR builds off the work by @lukewestby in https://github.com/avh4/elm-testable/pull/1.

It includes the changes mentioned in the feedback there (flipping the order of settings/requests, reordering the module) as well as adds the `assertHttpRequestWithSettings` and `resolveHttpRequestWithSettings` test helpers.
