### PR TITLE
Add Navigation and documentation

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
     "native-modules": true,
     "dependencies": {
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",
-        "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
+        "eeue56/elm-html-test": "4.1.0 <= v < 5.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
         "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/xavh4/elm-testable.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
         "src"

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/xavh4/elm-testable.git",
     "license": "BSD3",
     "source-directories": [
         "src"

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,6 +16,7 @@
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",
         "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
+        "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -6,7 +6,11 @@
     "source-directories": [
         "src"
     ],
-    "exposed-modules": [],
+    "exposed-modules": [
+        "Test.Http",
+        "Test.WebSocket",
+        "TestContext"
+    ],
     "native-modules": true,
     "dependencies": {
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -19,6 +19,7 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/examples/NavigationSample.elm
+++ b/examples/NavigationSample.elm
@@ -1,4 +1,4 @@
-module NavigationSample exposing (..)
+module NavigationSample exposing (program)
 
 import Html exposing (..)
 import Html.Attributes exposing (class)
@@ -6,8 +6,8 @@ import Html.Events exposing (..)
 import Navigation
 
 
-main : Program Never Model Msg
-main =
+program : Program Never Model Msg
+program =
     Navigation.program UrlChange
         { init = init
         , view = view
@@ -77,7 +77,7 @@ view model =
 
 viewLink : String -> Html Msg
 viewLink name =
-    li [ class name ] [ button [ onClick (Go <| "#" ++ name) ] [ text name ] ]
+    li [] [ button [ class name, onClick (Go <| "#" ++ name) ] [ text name ] ]
 
 
 viewLocation : Navigation.Location -> Html msg

--- a/examples/NavigationSample.elm
+++ b/examples/NavigationSample.elm
@@ -1,0 +1,85 @@
+module NavigationSample exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (class)
+import Html.Events exposing (..)
+import Navigation
+
+
+main : Program Never Model Msg
+main =
+    Navigation.program UrlChange
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { history : List Navigation.Location
+    }
+
+
+init : Navigation.Location -> ( Model, Cmd Msg )
+init location =
+    ( Model [ location ]
+    , Cmd.none
+    )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = UrlChange Navigation.Location
+    | Go String
+
+
+
+{- We are just storing the location in our history in this example, but
+   normally, you would use a package like evancz/url-parser to parse the path
+   or hash into nicely structured Elm values.
+       <http://package.elm-lang.org/packages/evancz/url-parser/latest>
+-}
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        UrlChange location ->
+            ( { model | history = location :: model.history }
+            , Cmd.none
+            )
+
+        Go path ->
+            ( model, Navigation.newUrl path )
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ h1 [] [ text "Pages" ]
+        , ul [] (List.map viewLink [ "bears", "cats", "dogs", "elephants", "fish" ])
+        , h1 [] [ text "History" ]
+        , ul [ class "history" ] (List.map viewLocation model.history)
+        ]
+
+
+viewLink : String -> Html Msg
+viewLink name =
+    li [ class name ] [ button [ onClick (Go <| "#" ++ name) ] [ text name ] ]
+
+
+viewLocation : Navigation.Location -> Html msg
+viewLocation location =
+    li [] [ text (location.pathname ++ location.hash) ]

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/xavh4/elm-testable.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -12,6 +12,7 @@
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -13,7 +13,8 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
-        "elm-lang/websocket": "1.0.2 <= v < 2.0.0"
+        "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/xavh4/elm-testable.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -1,0 +1,27 @@
+module NavigationSampleTests exposing (all)
+
+import Expect
+import NavigationSample exposing (Msg(..))
+import Test exposing (..)
+import Test.Html.Events as Events
+import Test.Html.Query exposing (..)
+import Test.Html.Selector exposing (..)
+import TestContext exposing (..)
+
+
+all : Test
+all =
+    describe "NavigationSample"
+        [ test "shows navigation " <|
+            \() ->
+                NavigationSample.main
+                    |> start
+                    |> simulate (find [ class "bears" ]) Events.Click
+                    |> simulate (find [ class "cats" ]) Events.Click
+                    |> expectView
+                    |> find [ class "history" ]
+                    |> Expect.all
+                        [ has [ text "#bears" ]
+                        , has [ text "#cats" ]
+                        ]
+        ]

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -15,7 +15,7 @@ all =
         [ test "renders navigation history" <|
             \() ->
                 NavigationSample.program
-                    |> start
+                    |> startWithLocation "http://example.com/"
                     |> simulate (findAll [ tag "button" ] >> index 2) Event.click
                     |> simulate (findAll [ tag "button" ] >> index 4) Event.click
                     |> expectView
@@ -26,7 +26,7 @@ all =
         , test "works for user initiated navigation" <|
             \() ->
                 NavigationSample.program
-                    |> start
+                    |> startWithLocation "http://example.com/"
                     |> navigate "/blog/?search=dogs"
                     |> expectView
                     |> has [ text "search for dogs" ]

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -1,7 +1,7 @@
 module NavigationSampleTests exposing (all)
 
 import Expect
-import NavigationSample exposing (Msg(..))
+import NavigationSample exposing (program)
 import Test exposing (..)
 import Test.Html.Events as Events
 import Test.Html.Query exposing (..)
@@ -12,9 +12,9 @@ import TestContext exposing (..)
 all : Test
 all =
     describe "NavigationSample"
-        [ test "shows navigation " <|
+        [ test "renders navigation history" <|
             \() ->
-                NavigationSample.main
+                NavigationSample.program
                     |> start
                     |> simulate (find [ class "bears" ]) Events.Click
                     |> simulate (find [ class "cats" ]) Events.Click
@@ -24,4 +24,12 @@ all =
                         [ has [ text "#bears" ]
                         , has [ text "#cats" ]
                         ]
+        , test "works for user initiated navigation" <|
+            \() ->
+                NavigationSample.program
+                    |> start
+                    |> navigate "#cats"
+                    |> expectView
+                    |> find [ class "history" ]
+                    |> has [ text "#cats" ]
         ]

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -21,8 +21,8 @@ all =
                     |> expectView
                     |> find [ class "history" ]
                     |> Expect.all
-                        [ has [ text "#bears" ]
-                        , has [ text "#cats" ]
+                        [ has [ text "/#bears" ]
+                        , has [ text "/#cats" ]
                         ]
         , test "works for user initiated navigation" <|
             \() ->
@@ -31,5 +31,5 @@ all =
                     |> navigate "#cats"
                     |> expectView
                     |> find [ class "history" ]
-                    |> has [ text "#cats" ]
+                    |> has [ text "/#cats" ]
         ]

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -16,20 +16,18 @@ all =
             \() ->
                 NavigationSample.program
                     |> start
-                    |> simulate (find [ class "bears" ]) Event.click
-                    |> simulate (find [ class "cats" ]) Event.click
+                    |> simulate (findAll [ tag "button" ] >> index 2) Event.click
+                    |> simulate (findAll [ tag "button" ] >> index 4) Event.click
                     |> expectView
-                    |> find [ class "history" ]
                     |> Expect.all
-                        [ has [ text "/#bears" ]
-                        , has [ text "/#cats" ]
+                        [ has [ text "show blog 42" ]
+                        , has [ text "search for cats" ]
                         ]
         , test "works for user initiated navigation" <|
             \() ->
                 NavigationSample.program
                     |> start
-                    |> navigate "#cats"
+                    |> navigate "/blog/?search=dogs"
                     |> expectView
-                    |> find [ class "history" ]
-                    |> has [ text "/#cats" ]
+                    |> has [ text "search for dogs" ]
         ]

--- a/examples/tests/NavigationSampleTests.elm
+++ b/examples/tests/NavigationSampleTests.elm
@@ -3,7 +3,7 @@ module NavigationSampleTests exposing (all)
 import Expect
 import NavigationSample exposing (program)
 import Test exposing (..)
-import Test.Html.Events as Events
+import Test.Html.Event as Event
 import Test.Html.Query exposing (..)
 import Test.Html.Selector exposing (..)
 import TestContext exposing (..)
@@ -16,8 +16,8 @@ all =
             \() ->
                 NavigationSample.program
                     |> start
-                    |> simulate (find [ class "bears" ]) Events.Click
-                    |> simulate (find [ class "cats" ]) Events.Click
+                    |> simulate (find [ class "bears" ]) Event.click
+                    |> simulate (find [ class "cats" ]) Event.click
                     |> expectView
                     |> find [ class "history" ]
                     |> Expect.all

--- a/examples/tests/Tests.elm
+++ b/examples/tests/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing (..)
 
+import NavigationSampleTests
 import RandomGifTests
 import Test exposing (..)
 import WebsocketChatTests
@@ -10,4 +11,5 @@ all =
     describe "avh4/elm-testable examples"
         [ RandomGifTests.all
         , WebsocketChatTests.all
+        , NavigationSampleTests.all
         ]

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Sample Elm Test",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/xavh4/elm-testable.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         ".",

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -14,6 +14,7 @@
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",
         "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
+        "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Sample Elm Test",
-    "repository": "https://github.com/xavh4/elm-testable.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         ".",

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -19,7 +19,8 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
-        "elm-lang/websocket": "1.0.2 <= v < 2.0.0"
+        "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -12,7 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",
-        "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
+        "eeue56/elm-html-test": "4.1.0 <= v < 5.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
         "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
       "_elm_lang$websocket$Native_WebSocket",
       "_elm_lang$websocket$WebSocket_LowLevel$open",
       "_elm_lang$websocket$WebSocket_LowLevel$send",
-      "_user$project$Testable_Task$andThen",
-      "_user$project$Testable_Task$onError"
+      "_xavh4$elm_testable$Testable_Task$andThen",
+      "_xavh4$elm_testable$Testable_Task$onError"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "elm-test": "^0.18.7"
   },
   "scripts": {
-    "test": "elm-make --yes && elm-test 'tests/**/*Tests.elm' && (cd examples && elm-make --yes RandomGif.elm && elm-test)"
+    "test": "elm-make --yes && elm-test 'tests/Tests.elm' && (cd examples && elm-make --yes RandomGif.elm && elm-test)"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "elm": "^0.18.0",
-    "elm-test": "^0.18.4"
+    "elm-test": "^0.18.7"
   },
   "scripts": {
     "test": "elm-make --yes && elm-test 'tests/**/*Tests.elm' && (cd examples && elm-make --yes RandomGif.elm && elm-test)"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
       "_elm_lang$websocket$Native_WebSocket",
       "_elm_lang$websocket$WebSocket_LowLevel$open",
       "_elm_lang$websocket$WebSocket_LowLevel$send",
-      "_xavh4$elm_testable$Testable_Task$andThen",
-      "_xavh4$elm_testable$Testable_Task$onError"
+      "_user$project$Testable_Task$andThen",
+      "_user$project$Testable_Task$onError"
     ]
   },
   "devDependencies": {

--- a/src/Native/Mapper.js
+++ b/src/Native/Mapper.js
@@ -1,4 +1,4 @@
-var _xavh4$elm_testable$Native_Mapper = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _user$project$Native_Mapper = (function () { // eslint-disable-line no-unused-vars, camelcase
   return {
     apply: F2(function (mapper, value) {
       // potentially crash if we can determine that value doesn't match the type of mapper's argument

--- a/src/Native/Mapper.js
+++ b/src/Native/Mapper.js
@@ -1,4 +1,4 @@
-var _user$project$Native_Mapper = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _xavh4$elm_testable$Native_Mapper = (function () { // eslint-disable-line no-unused-vars, camelcase
   return {
     apply: F2(function (mapper, value) {
       // potentially crash if we can determine that value doesn't match the type of mapper's argument

--- a/src/Native/TestContext.js
+++ b/src/Native/TestContext.js
@@ -114,6 +114,10 @@ var _user$project$Native_TestContext = (function () { // eslint-disable-line no-
       // This gets the return value from the modified
       // _elm_lang$core$Native_Platform.initialize above
       var app = containerModule.embed(embedRoot, realFlags)
+      var navigationInit;
+      if (program.elmTestable.navigationInit) {
+        navigationInit = realFlags ? program.elmTestable.navigationInit(realFlags) : program.elmTestable.navigationInit
+      }
 
       return {
         // TODO: just use the init in program.elmTestable instead of intecepting initialize
@@ -122,7 +126,8 @@ var _user$project$Native_TestContext = (function () { // eslint-disable-line no-
         update: program.elmTestable.update,
         subscriptions: program.elmTestable.subscriptions,
         view: program.elmTestable.view,
-        locationToMessage: program.elmTestable.locationToMessage || { ctor: 'Nothing' }
+        locationToMessage: program.elmTestable.locationToMessage || { ctor: 'Nothing' },
+        navigationInit: navigationInit ? { ctor: 'Just', _0: navigationInit } : { ctor: 'Nothing' }
       }
     }),
     extractCmd: F2(function (tagger, cmd) {

--- a/src/Native/TestContext.js
+++ b/src/Native/TestContext.js
@@ -47,7 +47,7 @@ _elm_lang$virtual_dom$Native_VirtualDom.program = setItUp2(
   })
 )
 
-var _user$project$Native_TestContext = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _xavh4$elm_testable$Native_TestContext = (function () { // eslint-disable-line no-unused-vars, camelcase
   // forEachLeaf : Tagger -> Cmd msg -> (Tagger -> LeafCmd -> IO ()) -> IO ()
   function forEachLeaf (tagger, bag, f) {
     switch (bag.type) {

--- a/src/Native/TestContext.js
+++ b/src/Native/TestContext.js
@@ -47,7 +47,7 @@ _elm_lang$virtual_dom$Native_VirtualDom.program = setItUp2(
   })
 )
 
-var _xavh4$elm_testable$Native_TestContext = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _user$project$Native_TestContext = (function () { // eslint-disable-line no-unused-vars, camelcase
   // forEachLeaf : Tagger -> Cmd msg -> (Tagger -> LeafCmd -> IO ()) -> IO ()
   function forEachLeaf (tagger, bag, f) {
     switch (bag.type) {

--- a/src/Native/TestContext.js
+++ b/src/Native/TestContext.js
@@ -121,7 +121,8 @@ var _xavh4$elm_testable$Native_TestContext = (function () { // eslint-disable-li
         init: app.init,
         update: program.elmTestable.update,
         subscriptions: program.elmTestable.subscriptions,
-        view: program.elmTestable.view
+        view: program.elmTestable.view,
+        locationToMessage: program.elmTestable.locationToMessage || { ctor: 'Nothing' }
       }
     }),
     extractCmd: F2(function (tagger, cmd) {

--- a/src/Native/Testable/EffectManager.js
+++ b/src/Native/Testable/EffectManager.js
@@ -1,4 +1,4 @@
-var _xavh4$elm_testable$Native_Testable_EffectManager = // eslint-disable-line no-unused-vars, camelcase
+var _user$project$Native_Testable_EffectManager = // eslint-disable-line no-unused-vars, camelcase
  (function () {
    var effectManagers
 

--- a/src/Native/Testable/EffectManager.js
+++ b/src/Native/Testable/EffectManager.js
@@ -1,4 +1,4 @@
-var _user$project$Native_Testable_EffectManager = // eslint-disable-line no-unused-vars, camelcase
+var _xavh4$elm_testable$Native_Testable_EffectManager = // eslint-disable-line no-unused-vars, camelcase
  (function () {
    var effectManagers
 

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -93,7 +93,8 @@ var rewireNavigation = function (realImplName, realImpl) {
         update: program.update,
         subscriptions: program.subscriptions,
         view: program.view,
-        locationToMessage: { ctor: 'Just', _0: locationToMessage }
+        locationToMessage: { ctor: 'Just', _0: locationToMessage },
+        navigationInit: stuff.init
       }
     })
   );

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -23,65 +23,48 @@ _elm_lang$navigation$Native_Navigation.getLocation = function () {
   }
 }
 
-_elm_lang$navigation$Native_Navigation.pushState = setItUp(
-  _elm_lang$navigation$Native_Navigation.pushState,
-  function (url) {
-    return {
-      ctor: 'Navigation_NativeNavigation',
-      _0: {
-        ctor: 'New',
-        _0: url
-      },
-      _1: function (url) { return { ctor: 'Success', _0: url } }
+var nativeNavigationRewire = function(args) {
+  _elm_lang$navigation$Native_Navigation[args.original] = setItUp(
+    _elm_lang$navigation$Native_Navigation[args.original],
+    function (data) {
+      return {
+        ctor: 'Navigation_NativeNavigation',
+        _0: {
+          ctor: args.mapCtor,
+          _0: data
+        },
+        _1: function (data) { return { ctor: 'Success', _0: data } }
+      }
     }
-  }
-)
-_elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
+  )
 
+  return _elm_lang$navigation$Native_Navigation[args.original];
+}
 
-_elm_lang$navigation$Native_Navigation.replaceState = setItUp(
-  _elm_lang$navigation$Native_Navigation.replaceState,
-  function (url) {
-    return {
-      ctor: 'Navigation_NativeNavigation',
-      _0: {
-        ctor: 'Modify',
-        _0: url
-      },
-      _1: function (url) { return { ctor: 'Success', _0: url } }
-    }
-  }
-)
-_elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
+_elm_lang$navigation$Navigation$pushState = nativeNavigationRewire({
+  original: 'pushState',
+  mapCtor: 'New'
+});
 
+_elm_lang$navigation$Navigation$replaceState = nativeNavigationRewire({
+  original: 'replaceState',
+  mapCtor: 'Modify'
+})
 
-_elm_lang$navigation$Native_Navigation.go = setItUp(
-  _elm_lang$navigation$Native_Navigation.go,
-  function (amount) {
-    return {
-      ctor: 'Navigation_NativeNavigation',
-      _0: {
-        ctor: 'Jump',
-        _0: amount
-      },
-      _1: function (amount) { return { ctor: 'Success', _0: amount } }
-    }
-  }
-)
-_elm_lang$navigation$Navigation$go = _elm_lang$navigation$Native_Navigation.go
-
+_elm_lang$navigation$Navigation$go = nativeNavigationRewire({
+  original: 'go',
+  mapCtor: 'Jump'
+})
 
 _elm_lang$navigation$Native_Navigation.reloadPage = function () {
   throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.reloadPage')
 }
 _elm_lang$navigation$Navigation$reloadPage = _elm_lang$navigation$Native_Navigation.reloadPage
 
-
-_elm_lang$navigation$Native_Navigation.setLocation = function () {
-  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.setLocation')
-}
-_elm_lang$navigation$Navigation$setLocation = _elm_lang$navigation$Native_Navigation.setLocation
-
+_elm_lang$navigation$Navigation$setLocation = nativeNavigationRewire({
+  original: 'setLocation',
+  mapCtor: 'Visit'
+})
 
 _elm_lang$navigation$Native_Navigation.isInternetExplorer11 = function () {
   return false
@@ -98,13 +81,11 @@ _elm_lang$dom$Native_Dom.onWindow = setItUp(
   })
 )
 _elm_lang$dom$Dom_LowLevel$onWindow = _elm_lang$dom$Native_Dom.onWindow
-_elm_lang$dom$Dom_LowLevel$onDocument = _elm_lang$dom$Native_Dom.onDocument
 
 _elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
   _elm_lang$navigation$Navigation$spawnPopWatcher,
   function () {
     return { ctor: 'IgnoredTask' }
-    // TODO
   }
 )
 

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -124,3 +124,20 @@ _elm_lang$navigation$Navigation$program = setItUp2(
     }
   })
 )
+
+var originalNavigationProgramWithFlags = _elm_lang$navigation$Navigation$program;
+_elm_lang$navigation$Navigation$programWithFlags = setItUp2(
+  '_elm_lang$navigation$Navigation$programWithFlags',
+  _elm_lang$navigation$Navigation$programWithFlags,
+  F2(function (locationToMessage, stuff) {
+    var original = originalNavigationProgramWithFlags(locationToMessage)(stuff).elmTestable;
+
+    return {
+      init: original.init,
+      update: original.update,
+      subscriptions: original.subscriptions,
+      view: original.view,
+      locationToMessage: { ctor: 'Just', _0: locationToMessage }
+    }
+  })
+)

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -1,0 +1,105 @@
+if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-disable-line camelcase
+  throw new Error('Native.Testable.Navigation was loaded before _elm_lang$navigation$Native_Navigation: this shouldn\'t happen because Testable.Navigation imports Navigation. Please report this at https://github.com/avh4/elm-testable/issues')
+}
+
+var href = "https://elm.testable/";
+
+_elm_lang$navigation$Native_Navigation.getLocation = function () {
+  var parser = href.match(/(.*?:)\/\/(.*?):?(\d+)?(\/.*?|$)(\?.*?|$)(#.*|$)/);
+  var protocol = parser[1];
+  var host = parser[2];
+  var port = parser[3] || '';
+  var path = parser[4] || '/';
+  var search = parser[5] || '';
+  var hash = parser[6] || '';
+
+  return {
+    href: href,
+    host: host,
+    hostname: host,
+    protocol: protocol,
+    origin: protocol + "//" + host,
+    port_: port,
+    pathname: path,
+    search: search,
+    hash: hash,
+    username: undefined,
+    password: undefined
+  }
+}
+
+_elm_lang$navigation$Native_Navigation.pushState = function () {
+  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.pushState')
+}
+_elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
+
+_elm_lang$navigation$Native_Navigation.replaceState = setItUp(
+  _elm_lang$navigation$Native_Navigation.replaceState,
+  function (url) {
+    var currentLocation = _elm_lang$navigation$Native_Navigation.getLocation();
+    if (url.match(/^\//)) {
+      href = currentLocation.origin + url;
+    } else if (url.match(/^\?/)) {
+      href = currentLocation.origin + currentLocation.pathname + url;
+    } else if (url.match(/^#/)) {
+      href = currentLocation.origin + currentLocation.pathname + currentLocation.search + url;
+    } else if (url.match(/^[a-z]+:\/\//i)) {
+      href = url;
+    } else {
+      href = currentLocation.origin + currentLocation.pathname.replace(/\/[^\/]*$/, "/" + url);
+    }
+
+    return { ctor: 'Success', _0: _elm_lang$navigation$Native_Navigation.getLocation() }
+  }
+)
+_elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
+
+
+_elm_lang$navigation$Native_Navigation.pushState = function () {
+  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.pushState')
+}
+_elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
+
+
+_elm_lang$navigation$Native_Navigation.go = function () {
+  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.go')
+}
+_elm_lang$navigation$Navigation$go = _elm_lang$navigation$Native_Navigation.go
+
+
+_elm_lang$navigation$Native_Navigation.reloadPage = function () {
+  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.reloadPage')
+}
+_elm_lang$navigation$Navigation$reloadPage = _elm_lang$navigation$Native_Navigation.reloadPage
+
+
+_elm_lang$navigation$Native_Navigation.setLocation = function () {
+  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.setLocation')
+}
+_elm_lang$navigation$Navigation$setLocation = _elm_lang$navigation$Native_Navigation.setLocation
+
+
+_elm_lang$navigation$Native_Navigation.isInternetExplorer11 = function () {
+  return false
+}
+
+
+if (typeof _elm_lang$dom$Native_Dom === 'undefined') { // eslint-disable-line camelcase
+  throw new Error('Native.Testable.Navigation was loaded before _elm_lang$dom$Native_Dom: this shouldn\'t happen because Testable.Navigation imports Dom. Please report this at https://github.com/avh4/elm-testable/issues')
+}
+_elm_lang$dom$Native_Dom.onWindow = setItUp(
+  _elm_lang$dom$Native_Dom.onWindow,
+  F3(function (eventName, decoder, toTask) {
+    return { ctor: 'IgnoredTask' }
+  })
+)
+_elm_lang$dom$Dom_LowLevel$onWindow = _elm_lang$dom$Native_Dom.onWindow;
+_elm_lang$dom$Dom_LowLevel$onDocument = _elm_lang$dom$Native_Dom.onDocument;
+
+_elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
+  _elm_lang$navigation$Navigation$spawnPopWatcher,
+  function () {
+    return { ctor: 'IgnoredTask' }
+    // TODO
+  }
+)

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -11,8 +11,11 @@ _elm_lang$navigation$Native_Navigation.pushState = setItUp(
   _elm_lang$navigation$Native_Navigation.pushState,
   function (url) {
     return {
-      ctor: 'Navigation_NativeNavigation_pushState',
-      _0: url,
+      ctor: 'Navigation_NativeNavigation',
+      _0: {
+        ctor: 'New',
+        _0: url
+      },
       _1: function (url) { return { ctor: 'Success', _0: url } }
     }
   }
@@ -24,8 +27,11 @@ _elm_lang$navigation$Native_Navigation.replaceState = setItUp(
   _elm_lang$navigation$Native_Navigation.replaceState,
   function (url) {
     return {
-      ctor: 'Navigation_NativeNavigation_replaceState',
-      _0: url,
+      ctor: 'Navigation_NativeNavigation',
+      _0: {
+        ctor: 'Modify',
+        _0: url
+      },
       _1: function (url) { return { ctor: 'Success', _0: url } }
     }
   }
@@ -33,9 +39,19 @@ _elm_lang$navigation$Native_Navigation.replaceState = setItUp(
 _elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
 
 
-_elm_lang$navigation$Native_Navigation.go = function () {
-  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.go')
-}
+_elm_lang$navigation$Native_Navigation.go = setItUp(
+  _elm_lang$navigation$Native_Navigation.go,
+  function (amount) {
+    return {
+      ctor: 'Navigation_NativeNavigation',
+      _0: {
+        ctor: 'Jump',
+        _0: amount
+      },
+      _1: function (amount) { return { ctor: 'Success', _0: amount } }
+    }
+  }
+);
 _elm_lang$navigation$Navigation$go = _elm_lang$navigation$Native_Navigation.go
 
 

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -3,9 +3,8 @@ if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-d
 }
 
 _elm_lang$navigation$Native_Navigation.getLocation = function () {
-  return _xavh4$elm_testable$Testable_Navigation$getLocation("https://elm.testable/");
+  return _xavh4$elm_testable$Testable_Navigation$initialLocation;
 }
-
 
 _elm_lang$navigation$Native_Navigation.pushState = setItUp(
   _elm_lang$navigation$Native_Navigation.pushState,
@@ -90,4 +89,21 @@ _elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
     return { ctor: 'IgnoredTask' }
     // TODO
   }
+)
+
+var originalNavigationProgram = _elm_lang$navigation$Navigation$program;
+_elm_lang$navigation$Navigation$program = setItUp2(
+  '_elm_lang$navigation$Navigation$program',
+  _elm_lang$navigation$Navigation$program,
+  F2(function (locationToMessage, stuff) {
+    var original = originalNavigationProgram(locationToMessage)(stuff).elmTestable;
+
+    return {
+      init: original.init,
+      update: original.update,
+      subscriptions: original.subscriptions,
+      view: original.view,
+      locationToMessage: { ctor: 'Just', _0: locationToMessage }
+    }
+  })
 )

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -23,102 +23,88 @@ _elm_lang$navigation$Native_Navigation.getLocation = function () {
   }
 }
 
-var nativeNavigationRewire = function(args) {
-  _elm_lang$navigation$Native_Navigation[args.original] = setItUp(
-    _elm_lang$navigation$Native_Navigation[args.original],
-    function (data) {
+var mapNavigation = function(ctor) {
+  return function (data) {
       return {
         ctor: 'Navigation_NativeNavigation',
         _0: {
-          ctor: args.mapCtor,
+          ctor: ctor,
           _0: data
         },
         _1: function (data) { return { ctor: 'Success', _0: data } }
       }
-    }
-  )
-
-  return _elm_lang$navigation$Native_Navigation[args.original];
+  }
 }
 
-_elm_lang$navigation$Navigation$pushState = nativeNavigationRewire({
-  original: 'pushState',
-  mapCtor: 'New'
-});
+_elm_lang$navigation$Navigation$pushState = setItUp(
+  _elm_lang$navigation$Navigation$pushState,
+  mapNavigation('New')
+)
 
-_elm_lang$navigation$Navigation$replaceState = nativeNavigationRewire({
-  original: 'replaceState',
-  mapCtor: 'Modify'
-})
+_elm_lang$navigation$Navigation$replaceState = setItUp(
+  _elm_lang$navigation$Navigation$replaceState,
+  mapNavigation('Modify')
+)
 
-_elm_lang$navigation$Navigation$go = nativeNavigationRewire({
-  original: 'go',
-  mapCtor: 'Jump'
-})
+_elm_lang$navigation$Navigation$go = setItUp(
+  _elm_lang$navigation$Navigation$go,
+  mapNavigation('Jump')
+)
 
-_elm_lang$navigation$Native_Navigation.reloadPage = function () {
-  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.reloadPage')
-}
-_elm_lang$navigation$Navigation$reloadPage = _elm_lang$navigation$Native_Navigation.reloadPage
+_elm_lang$navigation$Navigation$setLocation = setItUp(
+  _elm_lang$navigation$Navigation$setLocation,
+  mapNavigation('Visit')
+)
 
-_elm_lang$navigation$Navigation$setLocation = nativeNavigationRewire({
-  original: 'setLocation',
-  mapCtor: 'Visit'
-})
+_elm_lang$navigation$Navigation$reloadPage = setItUp(
+  _elm_lang$navigation$Navigation$reloadPage,
+  function () { return { ctor: 'IgnoredTask' } }
+)
+
+_elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
+  _elm_lang$navigation$Navigation$spawnPopWatcher,
+  function () { return { ctor: 'IgnoredTask' } }
+)
 
 _elm_lang$navigation$Native_Navigation.isInternetExplorer11 = function () {
   return false
 }
 
-
-if (typeof _elm_lang$dom$Native_Dom === 'undefined') { // eslint-disable-line camelcase
-  throw new Error('Native.Testable.Navigation was loaded before _elm_lang$dom$Native_Dom: this shouldn\'t happen because Testable.Navigation imports Dom. Please report this at https://github.com/avh4/elm-testable/issues')
+if (typeof _elm_lang$dom$Dom_LowLevel$onWindow === 'undefined') { // eslint-disable-line camelcase
+  throw new Error('Native.Testable.Navigation was loaded before _elm_lang$dom$Dom_LowLevel$onWindow: this shouldn\'t happen because Testable.Navigation imports Dom. Please report this at https://github.com/avh4/elm-testable/issues')
 }
-_elm_lang$dom$Native_Dom.onWindow = setItUp(
-  _elm_lang$dom$Native_Dom.onWindow,
+
+_elm_lang$dom$Dom_LowLevel$onWindow = setItUp(
+  _elm_lang$dom$Dom_LowLevel$onWindow,
   F3(function (eventName, decoder, toTask) {
     return { ctor: 'IgnoredTask' }
   })
 )
-_elm_lang$dom$Dom_LowLevel$onWindow = _elm_lang$dom$Native_Dom.onWindow
 
-_elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
-  _elm_lang$navigation$Navigation$spawnPopWatcher,
-  function () {
-    return { ctor: 'IgnoredTask' }
-  }
-)
+var rewireNavigation = function (realImplName, realImpl) {
+  return setItUp2(
+    realImplName,
+    realImpl,
+    F2(function (locationToMessage, stuff) {
+      var program = realImpl(locationToMessage)(stuff).elmTestable;
 
-var originalNavigationProgram = _elm_lang$navigation$Navigation$program;
-_elm_lang$navigation$Navigation$program = setItUp2(
+      return {
+        init: program.init,
+        update: program.update,
+        subscriptions: program.subscriptions,
+        view: program.view,
+        locationToMessage: { ctor: 'Just', _0: locationToMessage }
+      }
+    })
+  );
+}
+
+_elm_lang$navigation$Navigation$program = rewireNavigation(
   '_elm_lang$navigation$Navigation$program',
-  _elm_lang$navigation$Navigation$program,
-  F2(function (locationToMessage, stuff) {
-    var original = originalNavigationProgram(locationToMessage)(stuff).elmTestable;
+  _elm_lang$navigation$Navigation$program
+);
 
-    return {
-      init: original.init,
-      update: original.update,
-      subscriptions: original.subscriptions,
-      view: original.view,
-      locationToMessage: { ctor: 'Just', _0: locationToMessage }
-    }
-  })
-)
-
-var originalNavigationProgramWithFlags = _elm_lang$navigation$Navigation$program;
-_elm_lang$navigation$Navigation$programWithFlags = setItUp2(
+_elm_lang$navigation$Navigation$programWithFlags = rewireNavigation(
   '_elm_lang$navigation$Navigation$programWithFlags',
-  _elm_lang$navigation$Navigation$programWithFlags,
-  F2(function (locationToMessage, stuff) {
-    var original = originalNavigationProgramWithFlags(locationToMessage)(stuff).elmTestable;
-
-    return {
-      init: original.init,
-      update: original.update,
-      subscriptions: original.subscriptions,
-      view: original.view,
-      locationToMessage: { ctor: 'Just', _0: locationToMessage }
-    }
-  })
-)
+  _elm_lang$navigation$Navigation$programWithFlags
+);

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -6,9 +6,17 @@ _elm_lang$navigation$Native_Navigation.getLocation = function () {
   return _xavh4$elm_testable$Testable_Navigation$getLocation("https://elm.testable/");
 }
 
-_elm_lang$navigation$Native_Navigation.pushState = function () {
-  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.pushState')
-}
+
+_elm_lang$navigation$Native_Navigation.pushState = setItUp(
+  _elm_lang$navigation$Native_Navigation.pushState,
+  function (url) {
+    return {
+      ctor: 'Navigation_NativeNavigation_pushState',
+      _0: url,
+      _1: function (url) { return { ctor: 'Success', _0: url } }
+    }
+  }
+);
 _elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
 
 
@@ -23,12 +31,6 @@ _elm_lang$navigation$Native_Navigation.replaceState = setItUp(
   }
 );
 _elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
-
-
-_elm_lang$navigation$Native_Navigation.pushState = function () {
-  throw new Error('elm-testable not implemented: _elm_lang$navigation$Native_Navigation.pushState')
-}
-_elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
 
 
 _elm_lang$navigation$Native_Navigation.go = function () {

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -2,30 +2,8 @@ if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-d
   throw new Error('Native.Testable.Navigation was loaded before _elm_lang$navigation$Native_Navigation: this shouldn\'t happen because Testable.Navigation imports Navigation. Please report this at https://github.com/avh4/elm-testable/issues')
 }
 
-var href = "https://elm.testable/";
-
 _elm_lang$navigation$Native_Navigation.getLocation = function () {
-  var parser = href.match(/(.*?:)\/\/(.*?):?(\d+)?(\/.*?|$)(\?.*?|$)(#.*|$)/);
-  var protocol = parser[1];
-  var host = parser[2];
-  var port = parser[3] || '';
-  var path = parser[4] || '/';
-  var search = parser[5] || '';
-  var hash = parser[6] || '';
-
-  return {
-    href: href,
-    host: host,
-    hostname: host,
-    protocol: protocol,
-    origin: protocol + "//" + host,
-    port_: port,
-    pathname: path,
-    search: search,
-    hash: hash,
-    username: undefined,
-    password: undefined
-  }
+  return _xavh4$elm_testable$Testable_Navigation$getLocation("https://elm.testable/");
 }
 
 _elm_lang$navigation$Native_Navigation.pushState = function () {
@@ -33,25 +11,17 @@ _elm_lang$navigation$Native_Navigation.pushState = function () {
 }
 _elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
 
+
 _elm_lang$navigation$Native_Navigation.replaceState = setItUp(
   _elm_lang$navigation$Native_Navigation.replaceState,
   function (url) {
-    var currentLocation = _elm_lang$navigation$Native_Navigation.getLocation();
-    if (url.match(/^\//)) {
-      href = currentLocation.origin + url;
-    } else if (url.match(/^\?/)) {
-      href = currentLocation.origin + currentLocation.pathname + url;
-    } else if (url.match(/^#/)) {
-      href = currentLocation.origin + currentLocation.pathname + currentLocation.search + url;
-    } else if (url.match(/^[a-z]+:\/\//i)) {
-      href = url;
-    } else {
-      href = currentLocation.origin + currentLocation.pathname.replace(/\/[^\/]*$/, "/" + url);
+    return {
+      ctor: 'Navigation_NativeNavigation_replaceState',
+      _0: url,
+      _1: function (url) { return { ctor: 'Success', _0: url } }
     }
-
-    return { ctor: 'Success', _0: _elm_lang$navigation$Native_Navigation.getLocation() }
   }
-)
+);
 _elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
 
 

--- a/src/Native/Testable/Navigation.js
+++ b/src/Native/Testable/Navigation.js
@@ -2,8 +2,25 @@ if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-d
   throw new Error('Native.Testable.Navigation was loaded before _elm_lang$navigation$Native_Navigation: this shouldn\'t happen because Testable.Navigation imports Navigation. Please report this at https://github.com/avh4/elm-testable/issues')
 }
 
+var original_getLocation = _elm_lang$navigation$Native_Navigation.getLocation;
 _elm_lang$navigation$Native_Navigation.getLocation = function () {
-  return _xavh4$elm_testable$Testable_Navigation$initialLocation;
+  if (typeof document !== 'undefined' && typeof document.location !== 'undefined') {
+    return original_getLocation()
+  }
+
+  return {
+    href: 'https://elm.testable/',
+    host: 'elm.testable',
+    hostname: 'elm.testable',
+    protocol: 'https:',
+    origin: 'https://elm.testable',
+    port_: '',
+    pathname: '/',
+    search: '',
+    hash: '',
+    username: '',
+    password: ''
+  }
 }
 
 _elm_lang$navigation$Native_Navigation.pushState = setItUp(
@@ -18,7 +35,7 @@ _elm_lang$navigation$Native_Navigation.pushState = setItUp(
       _1: function (url) { return { ctor: 'Success', _0: url } }
     }
   }
-);
+)
 _elm_lang$navigation$Navigation$pushState = _elm_lang$navigation$Native_Navigation.pushState
 
 
@@ -34,7 +51,7 @@ _elm_lang$navigation$Native_Navigation.replaceState = setItUp(
       _1: function (url) { return { ctor: 'Success', _0: url } }
     }
   }
-);
+)
 _elm_lang$navigation$Navigation$replaceState = _elm_lang$navigation$Native_Navigation.replaceState
 
 
@@ -50,7 +67,7 @@ _elm_lang$navigation$Native_Navigation.go = setItUp(
       _1: function (amount) { return { ctor: 'Success', _0: amount } }
     }
   }
-);
+)
 _elm_lang$navigation$Navigation$go = _elm_lang$navigation$Native_Navigation.go
 
 
@@ -80,8 +97,8 @@ _elm_lang$dom$Native_Dom.onWindow = setItUp(
     return { ctor: 'IgnoredTask' }
   })
 )
-_elm_lang$dom$Dom_LowLevel$onWindow = _elm_lang$dom$Native_Dom.onWindow;
-_elm_lang$dom$Dom_LowLevel$onDocument = _elm_lang$dom$Native_Dom.onDocument;
+_elm_lang$dom$Dom_LowLevel$onWindow = _elm_lang$dom$Native_Dom.onWindow
+_elm_lang$dom$Dom_LowLevel$onDocument = _elm_lang$dom$Native_Dom.onDocument
 
 _elm_lang$navigation$Navigation$spawnPopWatcher = setItUp(
   _elm_lang$navigation$Navigation$spawnPopWatcher,

--- a/src/Native/Testable/Task.js
+++ b/src/Native/Testable/Task.js
@@ -37,6 +37,18 @@ _elm_lang$core$Native_Scheduler.sleep = setItUp(
 )
 _elm_lang$core$Process$sleep = _elm_lang$core$Native_Scheduler.sleep // eslint-disable-line no-global-assign, camelcase
 
+if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-disable-line camelcase
+  throw new Error('Native.Testable.Task was loaded before _elm_lang$navigation$Native_Navigation: this shouldn\'t happen because Testable.Task imports Navigation. Please report this at https://github.com/avh4/elm-testable/issues')
+}
+
+_elm_lang$navigation$Native_Navigation.pushState = setItUp(
+  _elm_lang$navigation$Native_Navigation.pushState,
+  function (url) {
+    console.log(url);
+    return null;
+  }
+)
+
 if (typeof _elm_lang$core$Process$spawn === 'undefined') { // eslint-disable-line camelcase
   throw new Error('Native.Testable.Task was loaded before _elm_lang$core$Process: this shouldn\'t happen because Testable.Task imports Process.  Please report this at https://github.com/avh4/elm-testable/issues')
 }

--- a/src/Native/Testable/Task.js
+++ b/src/Native/Testable/Task.js
@@ -57,7 +57,7 @@ _elm_lang$core$Native_Scheduler.spawn = setItUp(
     var t2 = _elm_lang$core$Task$onError(function (x) { return { ctor: 'IgnoredTask' } })(t1)
     return {
       ctor: 'Core_NativeScheduler_spawn',
-      _0: _xavh4$elm_testable$Native_Testable_Task.fromPlatformTask(t2),
+      _0: _user$project$Native_Testable_Task.fromPlatformTask(t2),
       _1: function (processId) { return { ctor: 'Success', _0: processId } }
     }
   }
@@ -121,7 +121,7 @@ _elm_lang$core$Time$setInterval = setItUp( // eslint-disable-line no-global-assi
     return {
       ctor: 'Core_Time_setInterval',
       _0: delay,
-      _1: _xavh4$elm_testable$Native_Testable_Task.fromPlatformTask(task)
+      _1: _user$project$Native_Testable_Task.fromPlatformTask(task)
     }
   })
 )
@@ -225,7 +225,7 @@ _elm_lang$websocket$Native_WebSocket.send = setItUp(
 )
 _elm_lang$websocket$WebSocket_LowLevel$send = _elm_lang$websocket$Native_WebSocket.send // eslint-disable-line no-global-assign, camelcase
 
-var _xavh4$elm_testable$Native_Testable_Task = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _user$project$Native_Testable_Task = (function () { // eslint-disable-line no-unused-vars, camelcase
   function fromPlatformTask (task) {
     if (task.elmTestable) return task.elmTestable
 
@@ -238,13 +238,13 @@ var _xavh4$elm_testable$Native_Testable_Task = (function () { // eslint-disable-
 
       case '_Task_andThen':
         var next = fromPlatformTask(task.task)
-        return _xavh4$elm_testable$Testable_Task$andThen(function (x) {
+        return _user$project$Testable_Task$andThen(function (x) {
           return fromPlatformTask(task.callback(x))
         })(next)
 
       case '_Task_onError':
         var next_ = fromPlatformTask(task.task)
-        return _xavh4$elm_testable$Testable_Task$onError(function (x) {
+        return _user$project$Testable_Task$onError(function (x) {
           return fromPlatformTask(task.callback(x))
         })(next_)
 

--- a/src/Native/Testable/Task.js
+++ b/src/Native/Testable/Task.js
@@ -52,7 +52,7 @@ _elm_lang$core$Native_Scheduler.spawn = setItUp(
     var t2 = _elm_lang$core$Task$onError(function (x) { return { ctor: 'IgnoredTask' } })(t1)
     return {
       ctor: 'Core_NativeScheduler_spawn',
-      _0: _user$project$Native_Testable_Task.fromPlatformTask(t2),
+      _0: _xavh4$elm_testable$Native_Testable_Task.fromPlatformTask(t2),
       _1: function (processId) { return { ctor: 'Success', _0: processId } }
     }
   }
@@ -116,7 +116,7 @@ _elm_lang$core$Time$setInterval = setItUp( // eslint-disable-line no-global-assi
     return {
       ctor: 'Core_Time_setInterval',
       _0: delay,
-      _1: _user$project$Native_Testable_Task.fromPlatformTask(task)
+      _1: _xavh4$elm_testable$Native_Testable_Task.fromPlatformTask(task)
     }
   })
 )
@@ -216,7 +216,7 @@ _elm_lang$websocket$Native_WebSocket.send = setItUp(
 )
 _elm_lang$websocket$WebSocket_LowLevel$send = _elm_lang$websocket$Native_WebSocket.send // eslint-disable-line no-global-assign, camelcase
 
-var _user$project$Native_Testable_Task = (function () { // eslint-disable-line no-unused-vars, camelcase
+var _xavh4$elm_testable$Native_Testable_Task = (function () { // eslint-disable-line no-unused-vars, camelcase
   function fromPlatformTask (task) {
     if (task.elmTestable) return task.elmTestable
 
@@ -229,13 +229,13 @@ var _user$project$Native_Testable_Task = (function () { // eslint-disable-line n
 
       case '_Task_andThen':
         var next = fromPlatformTask(task.task)
-        return _user$project$Testable_Task$andThen(function (x) {
+        return _xavh4$elm_testable$Testable_Task$andThen(function (x) {
           return fromPlatformTask(task.callback(x))
         })(next)
 
       case '_Task_onError':
         var next_ = fromPlatformTask(task.task)
-        return _user$project$Testable_Task$onError(function (x) {
+        return _xavh4$elm_testable$Testable_Task$onError(function (x) {
           return fromPlatformTask(task.callback(x))
         })(next_)
 

--- a/src/Native/Testable/Task.js
+++ b/src/Native/Testable/Task.js
@@ -1,10 +1,15 @@
-
 function setItUp (realImpl, elmTestableTask) {
   var realImpl_ = realImpl
   if (elmTestableTask.arity === 2) {
     return F2(function (a, b) {
       var real = realImpl_(a)(b)
       real.elmTestable = elmTestableTask(a)(b)
+      return real
+    })
+  } else if (elmTestableTask.arity === 3) {
+    return F3(function (a, b, c) {
+      var real = realImpl_(a)(b)(c)
+      real.elmTestable = elmTestableTask(a)(b)(c)
       return real
     })
   } else if (typeof realImpl !== 'function') {
@@ -36,18 +41,6 @@ _elm_lang$core$Native_Scheduler.sleep = setItUp(
   }
 )
 _elm_lang$core$Process$sleep = _elm_lang$core$Native_Scheduler.sleep // eslint-disable-line no-global-assign, camelcase
-
-if (typeof _elm_lang$navigation$Native_Navigation === 'undefined') { // eslint-disable-line camelcase
-  throw new Error('Native.Testable.Task was loaded before _elm_lang$navigation$Native_Navigation: this shouldn\'t happen because Testable.Task imports Navigation. Please report this at https://github.com/avh4/elm-testable/issues')
-}
-
-_elm_lang$navigation$Native_Navigation.pushState = setItUp(
-  _elm_lang$navigation$Native_Navigation.pushState,
-  function (url) {
-    console.log(url);
-    return null;
-  }
-)
 
 if (typeof _elm_lang$core$Process$spawn === 'undefined') { // eslint-disable-line camelcase
   throw new Error('Native.Testable.Task was loaded before _elm_lang$core$Process: this shouldn\'t happen because Testable.Task imports Process.  Please report this at https://github.com/avh4/elm-testable/issues')

--- a/src/Native/Testable/Task.js
+++ b/src/Native/Testable/Task.js
@@ -173,6 +173,10 @@ _elm_lang$http$Native_Http.toTask = setItUp(
   })
 )
 
+if (typeof _elm_lang$websocket$Native_WebSocket === 'undefined') {
+  throw new Error('Native.Testable.Task was loaded before _elm_lang$websocket$Native_WebSocket: this shouldn\'t happen because Testable.Task imports WebSocket.  Please report this at https://github.com/avh4/elm-testable/issues')
+}
+
 _elm_lang$websocket$Native_WebSocket.open = setItUp(
   _elm_lang$websocket$Native_WebSocket.open,
   F2(function (url, settings) {

--- a/src/Test/Http.elm
+++ b/src/Test/Http.elm
@@ -1,12 +1,27 @@
 module Test.Http
     exposing
-        ( badStatus
+        ( RequestMatcher
+        , badStatus
         , expectGet
         , expectRequest
         , rejectGet
         , resolveGet
         , resolveRequest
         )
+
+{-| Test.Http has helpers for you to mock and assert http responses
+
+
+# Responses
+
+@docs badStatus, resolveGet, rejectGet, resolveRequest
+
+
+# Assertions
+
+@docs RequestMatcher, expectGet, expectRequest
+
+-}
 
 import Dict exposing (Dict)
 import Expect exposing (Expectation)
@@ -15,6 +30,8 @@ import TestContextInternal as Internal exposing (TestContext(..))
 import Testable.Task exposing (ProcessId(..), Task(..), fromPlatformTask)
 
 
+{-| A type used for asserting requests
+-}
 type alias RequestMatcher =
     { method : String
     , url : String
@@ -31,6 +48,8 @@ type alias Response =
     }
 
 
+{-| Asserts that a get was called to the right url
+-}
 expectGet : String -> TestContext model msg -> Expectation
 expectGet url =
     expectRequest
@@ -41,6 +60,8 @@ expectGet url =
         }
 
 
+{-| Asserts that a request was made with the right method, url, headers and body
+-}
 expectRequest : RequestMatcher -> TestContext model msg -> Expectation
 expectRequest { method, url } =
     Internal.expect "Test.Http.expectRequest" identity <|
@@ -66,6 +87,8 @@ expectRequest { method, url } =
                     |> Expect.fail
 
 
+{-| Simulate a GET HTTP response
+-}
 resolveGet : String -> String -> TestContext model msg -> TestContext model msg
 resolveGet url body =
     resolveRequest
@@ -77,6 +100,8 @@ resolveGet url body =
         (Ok body)
 
 
+{-| A convenient way to create bad status responses
+-}
 badStatus : Int -> Http.Error
 badStatus statusCode =
     Http.BadStatus
@@ -92,6 +117,8 @@ badStatus statusCode =
         }
 
 
+{-| Simulate a GET HTTP request that had an error
+-}
 rejectGet : String -> Http.Error -> TestContext model msg -> TestContext model msg
 rejectGet url error =
     resolveRequest
@@ -103,6 +130,8 @@ rejectGet url error =
         (Err error)
 
 
+{-| Simulate any kind of HTTP responses that matches the given `RequestMatcher`
+-}
 resolveRequest : RequestMatcher -> Result Http.Error String -> TestContext model msg -> TestContext model msg
 resolveRequest { method, url } response =
     Internal.withContext <|
@@ -124,6 +153,8 @@ resolveRequest { method, url } response =
                         ("No HTTP request was made matching: " ++ method ++ " " ++ url)
 
 
+{-| Standard http status messages
+-}
 statusMessages : Dict Int String
 statusMessages =
     Dict.fromList

--- a/src/Test/WebSocket.elm
+++ b/src/Test/WebSocket.elm
@@ -1,5 +1,11 @@
 module Test.WebSocket exposing (acceptConnection, acceptMessage)
 
+{-| Test.WebSocket has helpers for you to test websockets
+
+@docs acceptConnection, acceptMessage
+
+-}
+
 import DefaultDict
 import Dict
 import Fifo
@@ -7,6 +13,8 @@ import TestContextInternal as Internal exposing (TestContext(..))
 import Testable.Task exposing (ProcessId(..))
 
 
+{-| Simulates an open websocket connection
+-}
 acceptConnection : String -> TestContext msg model -> TestContext msg model
 acceptConnection socketUrl =
     Internal.withContext <|
@@ -24,6 +32,8 @@ acceptConnection socketUrl =
                         |> Internal.drainWorkQueue
 
 
+{-| Asserts that the open websocket received some message
+-}
 acceptMessage : String -> String -> TestContext msg model -> TestContext msg model
 acceptMessage socketUrl expectedMessage =
     Internal.withContext <|

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -6,6 +6,7 @@ module TestContext
         , expectCmd
         , expectModel
         , expectView
+        , navigate
         , send
         , simulate
         , start
@@ -113,6 +114,13 @@ expectView context =
 simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> Event -> TestContext model msg -> TestContext model msg
 simulate eventTrigger event context =
     Internal.simulate eventTrigger event context
+
+
+{-| Simulates a browser navigation by the user
+-}
+navigate : String -> TestContext model msg -> TestContext model msg
+navigate url context =
+    Internal.navigate url context
 
 
 {-| Ends the test ensuring that no previous actions had errors

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -2,10 +2,12 @@ module TestContext
     exposing
         ( TestContext
         , advanceTime
+        , back
         , done
         , expectCmd
         , expectModel
         , expectView
+        , forward
         , navigate
         , send
         , simulate
@@ -27,7 +29,12 @@ allowing you to write integration tests.
 
 # Simulating Effects
 
-@docs advanceTime, send, simulate, navigate
+@docs advanceTime, send, simulate
+
+
+# Navigation
+
+@docs navigate, back, forward
 
 
 # Assertion
@@ -121,6 +128,20 @@ simulate eventTrigger event context =
 navigate : String -> TestContext model msg -> TestContext model msg
 navigate url context =
     Internal.navigate url context
+
+
+{-| Simulates a user hitting the back button on the browser
+-}
+back : TestContext model msg -> TestContext model msg
+back context =
+    Internal.back context
+
+
+{-| Simulates a user hitting the forward button on the browser
+-}
+forward : TestContext model msg -> TestContext model msg
+forward context =
+    Internal.forward context
 
 
 {-| Ends the test ensuring that no previous actions had errors

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -27,7 +27,7 @@ allowing you to write integration tests.
 
 # Simulating Effects
 
-@docs advanceTime, send, simulate
+@docs advanceTime, send, simulate, navigate
 
 
 # Assertion

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -13,6 +13,8 @@ module TestContext
         , simulate
         , start
         , startWithFlags
+        , startWithFlagsAndLocation
+        , startWithLocation
         , update
         )
 
@@ -24,7 +26,7 @@ allowing you to write integration tests.
 
 # Managing lifecycle
 
-@docs start, startWithFlags, update
+@docs start, startWithFlags, startWithLocation, startWithFlagsAndLocation, update
 
 
 # Simulating Effects
@@ -68,6 +70,20 @@ start realProgram =
 startWithFlags : flags -> Program flags model msg -> TestContext model msg
 startWithFlags flags realProgram =
     Internal.startWithFlags flags realProgram
+
+
+{-| Create a `TestContext` for a Navigation Program with location
+-}
+startWithLocation : String -> Program Never model msg -> TestContext model msg
+startWithLocation url realProgram =
+    Internal.startWithLocation url realProgram
+
+
+{-| Create a `TestContext` for a Navigation Program with flags and location
+-}
+startWithFlagsAndLocation : flags -> String -> Program flags model msg -> TestContext model msg
+startWithFlagsAndLocation flags url realProgram =
+    Internal.startWithFlagsAndLocation flags url realProgram
 
 
 {-| Update your program with a message, exercising its update flow

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -13,6 +13,28 @@ module TestContext
         , update
         )
 
+{-| A `TestContext` allows you to manage the lifecycle of an Elm app,
+allowing you to write integration tests.
+
+@docs TestContext
+
+
+# Managing lifecycle
+
+@docs start, startWithFlags, update
+
+
+# Simulating Effects
+
+@docs advanceTime, send, simulate
+
+
+# Assertion
+
+@docs expectCmd, expectModel, expectView, done
+
+-}
+
 import Expect exposing (Expectation)
 import Test.Html.Events exposing (Event)
 import Test.Html.Query
@@ -20,25 +42,35 @@ import TestContextInternal as Internal
 import Time exposing (Time)
 
 
+{-| Wraps a Program plus its context for making elm-testable assertions
+-}
 type alias TestContext model msg =
     Internal.TestContext model msg
 
 
+{-| Create a `TestContext` for the given Program
+-}
 start : Program Never model msg -> TestContext model msg
 start realProgram =
     Internal.start realProgram
 
 
+{-| Create a `TestContext` for a Program with flags
+-}
 startWithFlags : flags -> Program flags model msg -> TestContext model msg
 startWithFlags flags realProgram =
     Internal.startWithFlags flags realProgram
 
 
+{-| Update your program with a message, exercising its update flow
+-}
 update : msg -> TestContext model msg -> TestContext model msg
 update msg context =
     Internal.update msg context
 
 
+{-| Simulate a value being sent through a port
+-}
 send :
     ((value -> msg) -> Sub msg)
     -> value
@@ -48,31 +80,43 @@ send subPort value context =
     Internal.send subPort value context
 
 
+{-| Assert that a Cmd was called
+-}
 expectCmd : Cmd msg -> TestContext model msg -> Expectation
 expectCmd expected context =
     Internal.expectCmd expected context
 
 
+{-| Advances time, triggering delayed processes
+-}
 advanceTime : Time -> TestContext model msg -> TestContext model msg
 advanceTime dt context =
     Internal.advanceTime dt context
 
 
+{-| Write an assertion to check the current state of the Model
+-}
 expectModel : (model -> Expectation) -> TestContext model msg -> Expectation
 expectModel check context =
     Internal.expectModel check context
 
 
+{-| Write an assertion to check the current state of the View
+-}
 expectView : TestContext model msg -> Test.Html.Query.Single msg
 expectView context =
     Internal.expectView context
 
 
+{-| Simulate a DOM event being triggered on the view
+-}
 simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> Event -> TestContext model msg -> TestContext model msg
 simulate eventTrigger event context =
     Internal.simulate eventTrigger event context
 
 
+{-| Ends the test ensuring that no previous actions had errors
+-}
 done : TestContext model msg -> Expectation
 done =
     Internal.done

--- a/src/TestContext.elm
+++ b/src/TestContext.elm
@@ -37,7 +37,7 @@ allowing you to write integration tests.
 -}
 
 import Expect exposing (Expectation)
-import Test.Html.Events exposing (Event)
+import Json.Decode exposing (Value)
 import Test.Html.Query
 import TestContextInternal as Internal
 import Time exposing (Time)
@@ -111,7 +111,7 @@ expectView context =
 
 {-| Simulate a DOM event being triggered on the view
 -}
-simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> Event -> TestContext model msg -> TestContext model msg
+simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> ( String, Value ) -> TestContext model msg -> TestContext model msg
 simulate eventTrigger event context =
     Internal.simulate eventTrigger event context
 

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -39,6 +39,7 @@ import Test.Html.Events as Events exposing (Event)
 import Test.Html.Query
 import Test.Runner
 import Testable.EffectManager as EffectManager exposing (EffectManager)
+import Testable.Navigation
 import Testable.Task exposing (ProcessId(..), Task(..), fromPlatformTask)
 import Time exposing (Time)
 import WebSocket.LowLevel

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -31,13 +31,13 @@ import Expect exposing (Expectation)
 import Fifo exposing (Fifo)
 import Html exposing (Html)
 import Http
-import Json.Encode
+import Json.Encode exposing (Value)
 import Mapper exposing (Mapper)
 import Native.TestContext
 import Navigation exposing (Location)
 import PairingHeap exposing (PairingHeap)
 import Set exposing (Set)
-import Test.Html.Events as Events exposing (Event)
+import Test.Html.Event as Event exposing (Event)
 import Test.Html.Query
 import Test.Runner
 import Testable.EffectManager as EffectManager exposing (EffectManager)
@@ -940,13 +940,13 @@ expectView context =
             Html.text (report "expectView" context) |> Test.Html.Query.fromHtml
 
 
-simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> Event -> TestContext model msg -> TestContext model msg
+simulate : (Test.Html.Query.Single msg -> Test.Html.Query.Single msg) -> ( String, Value ) -> TestContext model msg -> TestContext model msg
 simulate eventTrigger event context =
     let
         eventResult =
             eventTrigger (expectView context)
-                |> Events.simulate event
-                |> Events.eventResult
+                |> Event.simulate event
+                |> Event.toResult
     in
     case eventResult of
         Ok msg ->

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -588,7 +588,7 @@ processTask pid task =
                 Navigation_NativeNavigation_replaceState url next ->
                     let
                         nextLocation =
-                            setLocation context.location url
+                            setLocation url context.location
                     in
                     TestContext { context | location = nextLocation }
                         |> processTask_preventTailCallOptimization pid (next nextLocation)

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -593,6 +593,14 @@ processTask pid task =
                     TestContext { context | location = nextLocation }
                         |> processTask_preventTailCallOptimization pid (next nextLocation)
 
+                Navigation_NativeNavigation_pushState url next ->
+                    let
+                        nextLocation =
+                            setLocation url context.location
+                    in
+                    TestContext { context | location = nextLocation }
+                        |> processTask_preventTailCallOptimization pid (next nextLocation)
+
 
 update : msg -> TestContext model msg -> TestContext model msg
 update msg =

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -111,7 +111,7 @@ type alias ActiveContext model msg =
     , msgTranscript : List ( Int, msg )
 
     -- navigation
-    , location : Location
+    , history : Testable.Navigation.History
     }
 
 
@@ -328,7 +328,7 @@ start_ flags realProgram =
         , msgTranscript = []
 
         -- navigation
-        , location = getLocation "https://elm.testable/"
+        , history = Testable.Navigation.init
         }
         |> initEffectManagers
         |> dispatchEffects
@@ -585,21 +585,13 @@ processTask pid task =
                         }
                         |> processTask_preventTailCallOptimization pid (next Nothing)
 
-                Navigation_NativeNavigation_replaceState url next ->
+                Navigation_NativeNavigation msg next ->
                     let
-                        nextLocation =
-                            setLocation url context.location
+                        ( history, location ) =
+                            Testable.Navigation.update msg context.history
                     in
-                    TestContext { context | location = nextLocation }
-                        |> processTask_preventTailCallOptimization pid (next nextLocation)
-
-                Navigation_NativeNavigation_pushState url next ->
-                    let
-                        nextLocation =
-                            setLocation url context.location
-                    in
-                    TestContext { context | location = nextLocation }
-                        |> processTask_preventTailCallOptimization pid (next nextLocation)
+                    TestContext { context | history = history }
+                        |> processTask_preventTailCallOptimization pid (next location)
 
 
 update : msg -> TestContext model msg -> TestContext model msg

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -3,6 +3,7 @@ module TestContextInternal
         ( MockTask
         , TestContext(..)
         , advanceTime
+        , back
         , done
           -- private to elm-testable
         , drainWorkQueue
@@ -12,6 +13,7 @@ module TestContextInternal
         , expectMockTask
         , expectModel
         , expectView
+        , forward
         , mockTask
         , navigate
         , processTask
@@ -963,13 +965,28 @@ done =
 
 navigate : String -> TestContext model msg -> TestContext model msg
 navigate url =
+    updateHistory (Testable.Navigation.New url)
+
+
+back : TestContext model msg -> TestContext model msg
+back =
+    updateHistory (Testable.Navigation.Jump -1)
+
+
+forward : TestContext model msg -> TestContext model msg
+forward =
+    updateHistory (Testable.Navigation.Jump 1)
+
+
+updateHistory : Testable.Navigation.Msg -> TestContext model msg -> TestContext model msg
+updateHistory msg =
     withContext <|
         \context ->
             case context.program.locationToMessage of
                 Just locationToMessage ->
                     let
                         ( history, nextLocation ) =
-                            Testable.Navigation.update (Testable.Navigation.New url) context.history
+                            Testable.Navigation.update msg context.history
 
                         location =
                             case nextLocation of

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -965,19 +965,19 @@ navigate url =
             case context.program.locationToMessage of
                 Just locationToMessage ->
                     let
-                        newLocation : Location
-                        newLocation =
-                            setLocation url (currentLocation context.history)
+                        ( history, nextLocation ) =
+                            Testable.Navigation.update (Testable.Navigation.New url) context.history
 
-                        ( index, history ) =
-                            context.history
+                        location =
+                            case nextLocation of
+                                Testable.Navigation.ReturnLocation location ->
+                                    location
 
-                        newHistory : Testable.Navigation.History
-                        newHistory =
-                            ( List.length history, history ++ [ newLocation ] )
+                                Testable.Navigation.TriggerLocationMsg location ->
+                                    location
                     in
-                    TestContext { context | history = newHistory }
-                        |> update (locationToMessage newLocation)
+                    TestContext { context | history = history }
+                        |> update (locationToMessage location)
 
                 Nothing ->
                     TestContext context

--- a/src/TestContextInternal.elm
+++ b/src/TestContextInternal.elm
@@ -609,6 +609,9 @@ processTask pid task =
                                 Nothing ->
                                     updatedTestContext location
 
+                        Testable.Navigation.NoOp ->
+                            TestContext { context | history = history }
+
 
 update : msg -> TestContext model msg -> TestContext model msg
 update msg =
@@ -975,6 +978,9 @@ navigate url =
 
                                 Testable.Navigation.TriggerLocationMsg location ->
                                     location
+
+                                Testable.Navigation.NoOp ->
+                                    currentLocation history
                     in
                     TestContext { context | history = history }
                         |> update (locationToMessage location)

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -39,7 +39,7 @@ update msg ( index, history ) =
         Jump n ->
             let
                 nextIndex =
-                    index + n
+                    min (max (index + n) 0) (List.length history - 1)
 
                 nextLocation =
                     List.Extra.getAt nextIndex history
@@ -51,8 +51,11 @@ update msg ( index, history ) =
             let
                 nextLocation =
                     setLocation url location
+
+                modifiedHistory =
+                    List.take (index + 1) history ++ [ nextLocation ]
             in
-            ( ( index + 1, history ++ [ nextLocation ] ), ReturnLocation nextLocation )
+            ( ( index + 1, modifiedHistory ), ReturnLocation nextLocation )
 
         Modify url ->
             let
@@ -98,6 +101,9 @@ getLocation href =
 
         host =
             matchOrEmptyAt 2
+
+        pathname =
+            Maybe.withDefault "/" (matchAt 4)
     in
     { href = href
     , host = host
@@ -105,7 +111,11 @@ getLocation href =
     , protocol = protocol
     , origin = protocol ++ "//" ++ host
     , port_ = matchOrEmptyAt 3
-    , pathname = Maybe.withDefault "/" (matchAt 4)
+    , pathname =
+        if String.isEmpty pathname then
+            "/"
+        else
+            pathname
     , search = matchOrEmptyAt 5
     , hash = matchOrEmptyAt 6
     , username = ""

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -138,6 +138,8 @@ getLocation href =
     }
 
 
+{-| TODO: Check this implementation against the specs <https://www.w3.org/TR/WD-html40-970708/htmlweb.html>
+-}
 setLocation : String -> Navigation.Location -> Navigation.Location
 setLocation url currentLocation =
     let

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -8,6 +8,55 @@ import Regex exposing (HowMany(..), find, regex)
 import Task exposing (Task)
 
 
+type alias History =
+    ( Int, List Location )
+
+
+type Msg
+    = Jump Int
+    | New String
+    | Modify String
+
+
+update : Msg -> History -> ( History, Location )
+update msg ( index, history ) =
+    let
+        currentLocation =
+            List.Extra.getAt index history
+                |> Maybe.withDefault (getLocation "")
+    in
+    case msg of
+        Jump n ->
+            let
+                nextIndex =
+                    index + n
+
+                location =
+                    List.Extra.getAt nextIndex history
+                        |> Maybe.withDefault (getLocation "")
+            in
+            ( ( nextIndex, history ), location )
+
+        New url ->
+            let
+                nextLocation =
+                    setLocation url currentLocation
+            in
+            ( ( index + 1, history ++ [ nextLocation ] ), nextLocation )
+
+        Modify url ->
+            let
+                nextLocation =
+                    setLocation url currentLocation
+            in
+            ( ( index + 1, history ++ [ nextLocation ] ), nextLocation )
+
+
+init : History
+init =
+    ( 0, [ getLocation "https://elm.testable/" ] )
+
+
 getLocation : String -> Navigation.Location
 getLocation href =
     let

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -84,14 +84,16 @@ update msg ( index, history ) =
             ( modifiedHistory, TriggerLocationMsg (currentLocation modifiedHistory) )
 
 
-init : History
-init =
-    ( 0, [ initialLocation ] )
+init : Maybe String -> History
+init url =
+    ( 0, [ initialLocation url ] )
 
 
-initialLocation : Location
-initialLocation =
-    getLocation "https://elm.testable/"
+initialLocation : Maybe String -> Location
+initialLocation url =
+    url
+        |> Maybe.withDefault "https://elm.testable/"
+        |> getLocation
 
 
 getLocation : String -> Navigation.Location

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -90,7 +90,7 @@ getLocation : String -> Navigation.Location
 getLocation href =
     let
         parser =
-            find All (regex "(.*?:)//(.*?):?(\\d+)?(/.*?|$)(\\?.*?|$)(#.*|$)") href
+            find All (regex "(.*?:)//(.*?):?(\\d+)?(/[^\\?^#]*)(\\?[^#]*)?(#.*)?") href
 
         matchAt index =
             List.head parser

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -18,12 +18,17 @@ type Msg
     | Modify String
 
 
+currentLocation : History -> Location
+currentLocation ( index, history ) =
+    List.Extra.getAt index history
+        |> Maybe.withDefault (getLocation "")
+
+
 update : Msg -> History -> ( History, Location )
 update msg ( index, history ) =
     let
-        currentLocation =
-            List.Extra.getAt index history
-                |> Maybe.withDefault (getLocation "")
+        location =
+            currentLocation ( index, history )
     in
     case msg of
         Jump n ->
@@ -40,21 +45,26 @@ update msg ( index, history ) =
         New url ->
             let
                 nextLocation =
-                    setLocation url currentLocation
+                    setLocation url location
             in
             ( ( index + 1, history ++ [ nextLocation ] ), nextLocation )
 
         Modify url ->
             let
                 nextLocation =
-                    setLocation url currentLocation
+                    setLocation url location
             in
             ( ( index + 1, history ++ [ nextLocation ] ), nextLocation )
 
 
 init : History
 init =
-    ( 0, [ getLocation "https://elm.testable/" ] )
+    ( 0, [ initialLocation ] )
+
+
+initialLocation : Location
+initialLocation =
+    getLocation "https://elm.testable/"
 
 
 getLocation : String -> Navigation.Location

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -45,8 +45,8 @@ getLocation href =
     }
 
 
-setLocation : Navigation.Location -> String -> Navigation.Location
-setLocation currentLocation url =
+setLocation : String -> Navigation.Location -> Navigation.Location
+setLocation url currentLocation =
     let
         nextHref =
             if Regex.contains (regex "^/") url then

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -1,8 +1,63 @@
 module Testable.Navigation exposing (..)
 
+import List.Extra
 import Native.Testable.Navigation
 import Navigation exposing (Location)
 import Process
+import Regex exposing (HowMany(..), find, regex)
 import Task exposing (Task)
 
-foo = "bar"
+
+getLocation : String -> Navigation.Location
+getLocation href =
+    let
+        parser =
+            find All (regex "(.*?:)//(.*?):?(\\d+)?(/.*?|$)(\\?.*?|$)(#.*|$)") href
+
+        matchAt index =
+            List.head parser
+                |> Maybe.andThen
+                    (.submatches
+                        >> List.Extra.getAt (index - 1)
+                        >> Maybe.withDefault Nothing
+                    )
+
+        matchOrEmptyAt index =
+            Maybe.withDefault "" (matchAt index)
+
+        protocol =
+            matchOrEmptyAt 1
+
+        host =
+            matchOrEmptyAt 2
+    in
+    { href = href
+    , host = host
+    , hostname = host
+    , protocol = protocol
+    , origin = protocol ++ "//" ++ host
+    , port_ = matchOrEmptyAt 3
+    , pathname = Maybe.withDefault "/" (matchAt 4)
+    , search = matchOrEmptyAt 5
+    , hash = matchOrEmptyAt 6
+    , username = ""
+    , password = ""
+    }
+
+
+setLocation : Navigation.Location -> String -> Navigation.Location
+setLocation currentLocation url =
+    let
+        nextHref =
+            if Regex.contains (regex "^/") url then
+                currentLocation.origin ++ url
+            else if Regex.contains (regex "^\\?") url then
+                currentLocation.origin ++ currentLocation.pathname ++ url
+            else if Regex.contains (regex "^#") url then
+                currentLocation.origin ++ currentLocation.pathname ++ currentLocation.search ++ url
+            else if Regex.contains (regex "^[A-z]+://") url then
+                url
+            else
+                currentLocation.origin ++ Regex.replace (AtMost 1) (regex "/[^/]*$") (\_ -> "/" ++ url) currentLocation.pathname
+    in
+    getLocation nextHref

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -16,6 +16,7 @@ type Msg
     = Jump Int
     | New String
     | Modify String
+    | Visit String
 
 
 type ReturnMsg
@@ -74,6 +75,13 @@ update msg ( index, history ) =
                         ReturnLocation nextLocation
             in
             ( ( index, modifiedHistory ), effect )
+
+        Visit url ->
+            let
+                ( modifiedHistory, _ ) =
+                    update (New url) ( index, history )
+            in
+            ( modifiedHistory, TriggerLocationMsg (currentLocation modifiedHistory) )
 
 
 init : History

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -1,0 +1,8 @@
+module Testable.Navigation exposing (..)
+
+import Native.Testable.Navigation
+import Navigation exposing (Location)
+import Process
+import Task exposing (Task)
+
+foo = "bar"

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -66,7 +66,7 @@ update msg ( index, history ) =
                     history
                         |> List.Extra.updateIfIndex ((==) index) (always nextLocation)
             in
-            ( ( index, history ), ReturnLocation nextLocation )
+            ( ( index, modifiedHistory ), ReturnLocation nextLocation )
 
 
 init : History

--- a/src/Testable/Navigation.elm
+++ b/src/Testable/Navigation.elm
@@ -19,7 +19,8 @@ type Msg
 
 
 type ReturnMsg
-    = ReturnLocation Location
+    = NoOp
+    | ReturnLocation Location
     | TriggerLocationMsg Location
 
 
@@ -65,8 +66,14 @@ update msg ( index, history ) =
                 modifiedHistory =
                     history
                         |> List.Extra.updateIfIndex ((==) index) (always nextLocation)
+
+                effect =
+                    if nextLocation == location then
+                        NoOp
+                    else
+                        ReturnLocation nextLocation
             in
-            ( ( index, modifiedHistory ), ReturnLocation nextLocation )
+            ( ( index, modifiedHistory ), effect )
 
 
 init : History

--- a/src/Testable/Task.elm
+++ b/src/Testable/Task.elm
@@ -72,6 +72,7 @@ type Task error success
     | WebSocket_NativeWebSocket_send String String (Maybe WebSocket.LowLevel.BadSend -> Task error success)
       -- Native bindings for tasks in elm-lang/Navigation
     | Navigation_NativeNavigation_replaceState String (Location -> Task error success)
+    | Navigation_NativeNavigation_pushState String (Location -> Task error success)
 
 
 {-| Transform a task.
@@ -149,6 +150,9 @@ andThen f source =
         Navigation_NativeNavigation_replaceState url next ->
             Navigation_NativeNavigation_replaceState url (next >> andThen f)
 
+        Navigation_NativeNavigation_pushState url next ->
+            Navigation_NativeNavigation_pushState url (next >> andThen f)
+
 
 
 -- Errors
@@ -221,3 +225,6 @@ onError f source =
 
         Navigation_NativeNavigation_replaceState url next ->
             Navigation_NativeNavigation_replaceState url (next >> onError f)
+
+        Navigation_NativeNavigation_pushState url next ->
+            Navigation_NativeNavigation_pushState url (next >> onError f)

--- a/src/Testable/Task.elm
+++ b/src/Testable/Task.elm
@@ -33,6 +33,7 @@ import
     Process
 import Task as PlatformTask
 import Testable.EffectManager as EffectManager
+import Testable.Navigation
 import Time exposing (Time)
 import WebSocket.LowLevel
 
@@ -71,8 +72,7 @@ type Task error success
     | WebSocket_NativeWebSocket_open String WebSocket.LowLevel.Settings (Result WebSocket.LowLevel.BadOpen () -> Task error success)
     | WebSocket_NativeWebSocket_send String String (Maybe WebSocket.LowLevel.BadSend -> Task error success)
       -- Native bindings for tasks in elm-lang/Navigation
-    | Navigation_NativeNavigation_replaceState String (Location -> Task error success)
-    | Navigation_NativeNavigation_pushState String (Location -> Task error success)
+    | Navigation_NativeNavigation Testable.Navigation.Msg (Location -> Task error success)
 
 
 {-| Transform a task.
@@ -147,11 +147,8 @@ andThen f source =
         WebSocket_NativeWebSocket_send url string next ->
             WebSocket_NativeWebSocket_send url string (next >> andThen f)
 
-        Navigation_NativeNavigation_replaceState url next ->
-            Navigation_NativeNavigation_replaceState url (next >> andThen f)
-
-        Navigation_NativeNavigation_pushState url next ->
-            Navigation_NativeNavigation_pushState url (next >> andThen f)
+        Navigation_NativeNavigation msg next ->
+            Navigation_NativeNavigation msg (next >> andThen f)
 
 
 
@@ -223,8 +220,5 @@ onError f source =
         WebSocket_NativeWebSocket_send url string next ->
             WebSocket_NativeWebSocket_send url string (next >> onError f)
 
-        Navigation_NativeNavigation_replaceState url next ->
-            Navigation_NativeNavigation_replaceState url (next >> onError f)
-
-        Navigation_NativeNavigation_pushState url next ->
-            Navigation_NativeNavigation_pushState url (next >> onError f)
+        Navigation_NativeNavigation msg next ->
+            Navigation_NativeNavigation msg (next >> onError f)

--- a/src/Testable/Task.elm
+++ b/src/Testable/Task.elm
@@ -26,6 +26,7 @@ internally by elm-testable to inspect and simulate Tasks.
 import Http
 import Mapper exposing (Mapper)
 import Native.Testable.Task
+import Navigation exposing (Location)
 import
     -- This "unused" import is required because Native.Testable.Task needs
     -- it at runtime:
@@ -69,6 +70,8 @@ type Task error success
       -- Native bindings for tasks in elm-lang/Websocket
     | WebSocket_NativeWebSocket_open String WebSocket.LowLevel.Settings (Result WebSocket.LowLevel.BadOpen () -> Task error success)
     | WebSocket_NativeWebSocket_send String String (Maybe WebSocket.LowLevel.BadSend -> Task error success)
+      -- Native bindings for tasks in elm-lang/Navigation
+    | Navigation_NativeNavigation_replaceState String (Location -> Task error success)
 
 
 {-| Transform a task.
@@ -143,6 +146,9 @@ andThen f source =
         WebSocket_NativeWebSocket_send url string next ->
             WebSocket_NativeWebSocket_send url string (next >> andThen f)
 
+        Navigation_NativeNavigation_replaceState url next ->
+            Navigation_NativeNavigation_replaceState url (next >> andThen f)
+
 
 
 -- Errors
@@ -212,3 +218,6 @@ onError f source =
 
         WebSocket_NativeWebSocket_send url string next ->
             WebSocket_NativeWebSocket_send url string (next >> onError f)
+
+        Navigation_NativeNavigation_replaceState url next ->
+            Navigation_NativeNavigation_replaceState url (next >> onError f)

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -61,16 +61,38 @@ all =
             \() ->
                 sampleProgram
                     |> expectHref "https://elm.testable/"
-        , test "pushUrl" <|
-            \() ->
-                sampleProgram
-                    |> update (PushUrl "/foo")
-                    |> expectHref "https://elm.testable/foo"
-        , test "modifyUrl" <|
-            \() ->
-                sampleProgram
-                    |> update (ModifyUrl "/foo")
-                    |> expectHref "https://elm.testable/foo"
+        , describe "pushUrl"
+            [ test "goes to a new url" <|
+                \() ->
+                    sampleProgram
+                        |> update (PushUrl "/foo")
+                        |> expectHref "https://elm.testable/foo"
+            , test "erases forward history" <|
+                \() ->
+                    sampleProgram
+                        |> update (PushUrl "/foo")
+                        |> update (Back 1)
+                        |> update (PushUrl "/baz")
+                        |> update (Back 100)
+                        |> update (Forward 1)
+                        |> expectHref "https://elm.testable/baz"
+            ]
+        , describe "modifyUrl"
+            [ test "changes current url" <|
+                \() ->
+                    sampleProgram
+                        |> update (ModifyUrl "/foo")
+                        |> expectHref "https://elm.testable/foo"
+            , test "does not erase forward history" <|
+                \() ->
+                    sampleProgram
+                        |> update (PushUrl "/foo")
+                        |> update (PushUrl "/bar")
+                        |> update (Back 1)
+                        |> update (ModifyUrl "/baz")
+                        |> update (Forward 1)
+                        |> expectHref "https://elm.testable/bar"
+            ]
         , describe "navigation simulation"
             [ test "simulates navigation for testing" <|
                 \() ->
@@ -101,6 +123,11 @@ all =
                         |> update (ModifyUrl "/baz")
                         |> update (Back 1)
                         |> expectHref "https://elm.testable/foo"
+            , test "has a limit to go back" <|
+                \() ->
+                    sampleProgram
+                        |> update (Back 100)
+                        |> expectHref "https://elm.testable/"
             ]
         , describe "forward"
             [ test "goes to the next page in history using forward" <|
@@ -119,6 +146,13 @@ all =
                         |> update (ModifyUrl "/baz")
                         |> update (Back 2)
                         |> update (Forward 1)
+                        |> expectHref "https://elm.testable/foo"
+            , test "has a limit to go forward" <|
+                \() ->
+                    sampleProgram
+                        |> update (PushUrl "/foo")
+                        |> update (Back 1)
+                        |> update (Forward 100)
                         |> expectHref "https://elm.testable/foo"
             ]
         ]

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -4,7 +4,7 @@ import Expect
 import Html exposing (..)
 import Navigation
 import Test exposing (..)
-import TestContext exposing (TestContext)
+import TestContext exposing (..)
 
 
 type Msg
@@ -67,6 +67,11 @@ all =
                 stringProgram
                     |> TestContext.update (ModifyUrl "/foo")
                     |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
+        , test "simulates navigation for testing" <|
+            \() ->
+                stringProgram
+                    |> navigate "/qux"
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/qux")
         , describe "back"
             [ test "returns to the previous url when using back" <|
                 \() ->

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -18,12 +18,12 @@ type Msg
 
 
 type alias Model =
-    { location : Navigation.Location, msgs : List Msg }
+    { location : Navigation.Location }
 
 
 init : Navigation.Location -> ( Model, Cmd Msg )
 init location =
-    ( { location = location, msgs = [] }, Cmd.none )
+    ( { location = location }, Cmd.none )
 
 
 initWithStringFlags : String -> Navigation.Location -> ( Model, Cmd Msg )
@@ -35,7 +35,7 @@ programUpdate : Msg -> Model -> ( Model, Cmd Msg )
 programUpdate msg model =
     case msg of
         UrlChange location ->
-            ( { model | location = location, msgs = msg :: model.msgs }, Navigation.modifyUrl location.pathname )
+            ( { model | location = location }, Navigation.modifyUrl location.pathname )
 
         PushUrl url ->
             ( model, Navigation.newUrl url )

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -9,6 +9,7 @@ import TestContext exposing (TestContext)
 
 type Msg
     = UrlChange Navigation.Location
+    | AskToPushUrl String
     | AskToModifyUrl String
 
 
@@ -26,6 +27,9 @@ update msg model =
     case msg of
         UrlChange location ->
             ( { model | location = location, msgs = msg :: model.msgs }, Cmd.none )
+
+        AskToPushUrl url ->
+            ( model, Navigation.newUrl url )
 
         AskToModifyUrl url ->
             ( model, Navigation.modifyUrl url )
@@ -49,6 +53,11 @@ all =
             \() ->
                 stringProgram
                     |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/")
+        , test "pushUrl" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToPushUrl "/foo")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
         , test "modifyUrl" <|
             \() ->
                 stringProgram

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -1,7 +1,7 @@
 module NavigationTests exposing (..)
 
 import Expect
-import Html
+import Html exposing (..)
 import Navigation
 import Test exposing (..)
 import TestContext exposing (TestContext)
@@ -9,15 +9,35 @@ import TestContext exposing (TestContext)
 
 type Msg
     = UrlChange Navigation.Location
+    | AskToModifyUrl String
 
 
-stringProgram : TestContext String Msg
+type alias Model =
+    { location : Navigation.Location, msgs : List Msg }
+
+
+init : Navigation.Location -> ( Model, Cmd Msg )
+init location =
+    ( { location = location, msgs = [] }, Cmd.none )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        UrlChange location ->
+            ( { model | location = location, msgs = msg :: model.msgs }, Cmd.none )
+
+        AskToModifyUrl url ->
+            ( model, Navigation.modifyUrl url )
+
+
+stringProgram : TestContext Model Msg
 stringProgram =
     Navigation.program UrlChange
-        { init = \location -> ( toString location, Cmd.none )
-        , update = \msg model -> ( model ++ ";" ++ toString msg, Cmd.none )
+        { init = init
+        , update = update
         , subscriptions = \_ -> Sub.none
-        , view = Html.text
+        , view = always <| div [] []
         }
         |> TestContext.start
 
@@ -28,5 +48,33 @@ all =
         [ test "starting a navigation program" <|
             \() ->
                 stringProgram
-                    |> TestContext.expectModel (Expect.equal "")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/")
+        , test "updates the root path" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToModifyUrl "/foo")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
+        , test "updates to a relative path" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToModifyUrl "/foo/bar")
+                    |> TestContext.update (AskToModifyUrl "baz")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo/baz")
+        , test "updates the query string" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToModifyUrl "/foo")
+                    |> TestContext.update (AskToModifyUrl "?q=bar")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo?q=bar")
+        , test "updates the hash" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToModifyUrl "/foo?bar#baz")
+                    |> TestContext.update (AskToModifyUrl "#qux")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo?bar#qux")
+        , test "updates the whole path" <|
+            \() ->
+                stringProgram
+                    |> TestContext.update (AskToModifyUrl "http://www.google.com")
+                    |> TestContext.expectModel (.location >> .href >> Expect.equal "http://www.google.com")
         ]

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -106,6 +106,15 @@ all =
                         |> navigate "/bar"
                         |> update (Back 1)
                         |> expectHref "https://elm.testable/foo"
+            , test "erases forward history" <|
+                \() ->
+                    sampleProgram
+                        |> navigate "/foo"
+                        |> update (Back 1)
+                        |> navigate "/baz"
+                        |> update (Back 100)
+                        |> update (Forward 1)
+                        |> expectHref "https://elm.testable/baz"
             ]
         , describe "back"
             [ test "returns to the previous url when using back" <|

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -61,38 +61,31 @@ all =
             \() ->
                 sampleProgram
                     |> expectHref "https://elm.testable/"
-        , describe "pushUrl"
-            [ test "goes to a new url" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> expectHref "https://elm.testable/foo"
-            , test "erases forward history" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (Back 1)
-                        |> update (PushUrl "/baz")
-                        |> update (Back 100)
-                        |> update (Forward 1)
-                        |> expectHref "https://elm.testable/baz"
-            ]
-        , describe "modifyUrl"
-            [ test "changes current url" <|
-                \() ->
-                    sampleProgram
-                        |> update (ModifyUrl "/foo")
-                        |> expectHref "https://elm.testable/foo"
-            , test "does not erase forward history" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (PushUrl "/bar")
-                        |> update (Back 1)
-                        |> update (ModifyUrl "/baz")
-                        |> update (Forward 1)
-                        |> expectHref "https://elm.testable/bar"
-            ]
+        , test "pushUrl" <|
+            \() ->
+                sampleProgram
+                    |> update (PushUrl "/foo")
+                    |> expectHref "https://elm.testable/foo"
+        , test "modifyUrl" <|
+            \() ->
+                sampleProgram
+                    |> update (ModifyUrl "/foo")
+                    |> expectHref "https://elm.testable/foo"
+        , test "back" <|
+            \() ->
+                sampleProgram
+                    |> update (PushUrl "/foo")
+                    |> update (PushUrl "/bar")
+                    |> update (Back 1)
+                    |> expectHref "https://elm.testable/foo"
+        , test "forward" <|
+            \() ->
+                sampleProgram
+                    |> update (PushUrl "/bar")
+                    |> update (PushUrl "/baz")
+                    |> update (Back 2)
+                    |> update (Forward 1)
+                    |> expectHref "https://elm.testable/bar"
         , describe "navigation simulation"
             [ test "simulates navigation for testing" <|
                 \() ->
@@ -115,54 +108,6 @@ all =
                         |> update (Back 100)
                         |> update (Forward 1)
                         |> expectHref "https://elm.testable/baz"
-            ]
-        , describe "back"
-            [ test "returns to the previous url when using back" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (PushUrl "/bar")
-                        |> update (Back 1)
-                        |> expectHref "https://elm.testable/foo"
-            , test "skip modified url" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (PushUrl "/bar")
-                        |> update (ModifyUrl "/baz")
-                        |> update (Back 1)
-                        |> expectHref "https://elm.testable/foo"
-            , test "has a limit to go back" <|
-                \() ->
-                    sampleProgram
-                        |> update (Back 100)
-                        |> expectHref "https://elm.testable/"
-            ]
-        , describe "forward"
-            [ test "goes to the next page in history using forward" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/bar")
-                        |> update (PushUrl "/baz")
-                        |> update (Back 2)
-                        |> update (Forward 1)
-                        |> expectHref "https://elm.testable/bar"
-            , test "skip modified url" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (PushUrl "/bar")
-                        |> update (ModifyUrl "/baz")
-                        |> update (Back 2)
-                        |> update (Forward 1)
-                        |> expectHref "https://elm.testable/foo"
-            , test "has a limit to go forward" <|
-                \() ->
-                    sampleProgram
-                        |> update (PushUrl "/foo")
-                        |> update (Back 1)
-                        |> update (Forward 100)
-                        |> expectHref "https://elm.testable/foo"
             ]
         ]
 

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -13,6 +13,7 @@ type Msg
     | ModifyUrl String
     | Back Int
     | Forward Int
+    | Load String
 
 
 type alias Model =
@@ -46,6 +47,9 @@ programUpdate msg model =
 
         Forward amount ->
             ( model, Navigation.forward amount )
+
+        Load url ->
+            ( model, Navigation.load url )
 
 
 sampleProgram : TestContext Model Msg
@@ -102,6 +106,11 @@ all =
                     |> update (Back 2)
                     |> update (Forward 1)
                     |> expectHref "https://elm.testable/bar"
+        , test "load" <|
+            \() ->
+                sampleProgram
+                    |> update (Load "/foo")
+                    |> expectHref "https://elm.testable/foo"
         , describe "navigation simulation"
             [ test "simulates navigation for testing" <|
                 \() ->

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -18,17 +18,17 @@ type Msg
 
 
 type alias Model =
-    { location : Navigation.Location }
+    { location : Navigation.Location, flags : String }
 
 
-init : Navigation.Location -> ( Model, Cmd Msg )
-init location =
-    ( { location = location }, Cmd.none )
+init : String -> Navigation.Location -> ( Model, Cmd Msg )
+init flags location =
+    ( { location = location, flags = flags }, Cmd.none )
 
 
 initWithStringFlags : String -> Navigation.Location -> ( Model, Cmd Msg )
 initWithStringFlags flags location =
-    init location
+    init flags location
 
 
 programUpdate : Msg -> Model -> ( Model, Cmd Msg )
@@ -59,7 +59,7 @@ programUpdate msg model =
 sampleProgram : TestContext Model Msg
 sampleProgram =
     Navigation.program UrlChange
-        { init = init
+        { init = init ""
         , update = programUpdate
         , subscriptions = \_ -> Sub.none
         , view = always <| div [] []
@@ -67,15 +67,15 @@ sampleProgram =
         |> TestContext.start
 
 
-sampleProgramWithFlags : TestContext Model Msg
-sampleProgramWithFlags =
+sampleProgramWithFlags : String -> TestContext Model Msg
+sampleProgramWithFlags flags =
     Navigation.programWithFlags UrlChange
         { init = initWithStringFlags
         , update = programUpdate
         , subscriptions = \_ -> Sub.none
         , view = always <| div [] []
         }
-        |> TestContext.startWithFlags "foo"
+        |> TestContext.startWithFlags flags
 
 
 all : Test
@@ -145,9 +145,16 @@ all =
             ]
         , test "works on program with flags" <|
             \() ->
-                sampleProgramWithFlags
+                sampleProgramWithFlags "something"
                     |> navigate "/foo"
                     |> expectHref "https://elm.testable/foo"
+        , test "flags are used" <|
+            \() ->
+                sampleProgramWithFlags "barbaz"
+                    |> expectModel
+                        (\model ->
+                            Expect.equal "barbaz" model.flags
+                        )
         ]
 
 

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -131,16 +131,18 @@ all =
                     sampleProgram
                         |> navigate "/foo"
                         |> navigate "/bar"
-                        |> update (Back 1)
+                        |> back
                         |> expectHref "https://elm.testable/foo"
             , test "erases forward history" <|
                 \() ->
                     sampleProgram
                         |> navigate "/foo"
-                        |> update (Back 1)
+                        |> back
                         |> navigate "/baz"
-                        |> update (Back 100)
-                        |> update (Forward 1)
+                        |> back
+                        |> back
+                        |> back
+                        |> forward
                         |> expectHref "https://elm.testable/baz"
             ]
         , test "works on program with flags" <|

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -12,6 +12,7 @@ type Msg
     | PushUrl String
     | ModifyUrl String
     | Back Int
+    | Forward Int
 
 
 type alias Model =
@@ -37,6 +38,9 @@ update msg model =
 
         Back amount ->
             ( model, Navigation.back amount )
+
+        Forward amount ->
+            ( model, Navigation.forward amount )
 
 
 stringProgram : TestContext Model Msg
@@ -80,14 +84,6 @@ all =
                         |> TestContext.update (PushUrl "/bar")
                         |> TestContext.update (Back 1)
                         |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
-            , test "returns two times" <|
-                \() ->
-                    stringProgram
-                        |> TestContext.update (PushUrl "/foo")
-                        |> TestContext.update (PushUrl "/bar")
-                        |> TestContext.update (PushUrl "/baz")
-                        |> TestContext.update (Back 2)
-                        |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
             , test "skip modified url" <|
                 \() ->
                     stringProgram
@@ -95,6 +91,25 @@ all =
                         |> TestContext.update (PushUrl "/bar")
                         |> TestContext.update (ModifyUrl "/baz")
                         |> TestContext.update (Back 1)
+                        |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
+            ]
+        , describe "forward"
+            [ test "goes to the next page in history using forward" <|
+                \() ->
+                    stringProgram
+                        |> TestContext.update (PushUrl "/bar")
+                        |> TestContext.update (PushUrl "/baz")
+                        |> TestContext.update (Back 2)
+                        |> TestContext.update (Forward 1)
+                        |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/bar")
+            , test "skip modified url" <|
+                \() ->
+                    stringProgram
+                        |> TestContext.update (PushUrl "/foo")
+                        |> TestContext.update (PushUrl "/bar")
+                        |> TestContext.update (ModifyUrl "/baz")
+                        |> TestContext.update (Back 2)
+                        |> TestContext.update (Forward 1)
                         |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
             ]
         ]

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -1,0 +1,32 @@
+module NavigationTests exposing (..)
+
+import Expect
+import Html
+import Navigation
+import Test exposing (..)
+import TestContext exposing (TestContext)
+
+
+type Msg
+    = UrlChange Navigation.Location
+
+
+stringProgram : TestContext String Msg
+stringProgram =
+    Navigation.program UrlChange
+        { init = \location -> ( toString location, Cmd.none )
+        , update = \msg model -> ( model ++ ";" ++ toString msg, Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        , view = Html.text
+        }
+        |> TestContext.start
+
+
+all : Test
+all =
+    describe "Navigation"
+        [ test "starting a navigation program" <|
+            \() ->
+                stringProgram
+                    |> TestContext.expectModel (Expect.equal "")
+        ]

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -24,6 +24,11 @@ init location =
     ( { location = location, msgs = [] }, Cmd.none )
 
 
+initWithStringFlags : String -> Navigation.Location -> ( Model, Cmd Msg )
+initWithStringFlags flags location =
+    init location
+
+
 programUpdate : Msg -> Model -> ( Model, Cmd Msg )
 programUpdate msg model =
     case msg of
@@ -52,6 +57,17 @@ sampleProgram =
         , view = always <| div [] []
         }
         |> TestContext.start
+
+
+sampleProgramWithFlags : TestContext Model Msg
+sampleProgramWithFlags =
+    Navigation.programWithFlags UrlChange
+        { init = initWithStringFlags
+        , update = programUpdate
+        , subscriptions = \_ -> Sub.none
+        , view = always <| div [] []
+        }
+        |> TestContext.startWithFlags "foo"
 
 
 all : Test
@@ -109,6 +125,11 @@ all =
                         |> update (Forward 1)
                         |> expectHref "https://elm.testable/baz"
             ]
+        , test "works on program with flags" <|
+            \() ->
+                sampleProgramWithFlags
+                    |> navigate "/foo"
+                    |> expectHref "https://elm.testable/foo"
         ]
 
 

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -28,7 +28,7 @@ programUpdate : Msg -> Model -> ( Model, Cmd Msg )
 programUpdate msg model =
     case msg of
         UrlChange location ->
-            ( { model | location = location, msgs = msg :: model.msgs }, Cmd.none )
+            ( { model | location = location, msgs = msg :: model.msgs }, Navigation.modifyUrl location.pathname )
 
         PushUrl url ->
             ( model, Navigation.newUrl url )

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -44,37 +44,14 @@ stringProgram =
 
 all : Test
 all =
-    describe "Navigation"
+    describe "Navigation TestContext"
         [ test "starting a navigation program" <|
             \() ->
                 stringProgram
                     |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/")
-        , test "updates the root path" <|
+        , test "modifyUrl" <|
             \() ->
                 stringProgram
                     |> TestContext.update (AskToModifyUrl "/foo")
                     |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo")
-        , test "updates to a relative path" <|
-            \() ->
-                stringProgram
-                    |> TestContext.update (AskToModifyUrl "/foo/bar")
-                    |> TestContext.update (AskToModifyUrl "baz")
-                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo/baz")
-        , test "updates the query string" <|
-            \() ->
-                stringProgram
-                    |> TestContext.update (AskToModifyUrl "/foo")
-                    |> TestContext.update (AskToModifyUrl "?q=bar")
-                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo?q=bar")
-        , test "updates the hash" <|
-            \() ->
-                stringProgram
-                    |> TestContext.update (AskToModifyUrl "/foo?bar#baz")
-                    |> TestContext.update (AskToModifyUrl "#qux")
-                    |> TestContext.expectModel (.location >> .href >> Expect.equal "https://elm.testable/foo?bar#qux")
-        , test "updates the whole path" <|
-            \() ->
-                stringProgram
-                    |> TestContext.update (AskToModifyUrl "http://www.google.com")
-                    |> TestContext.expectModel (.location >> .href >> Expect.equal "http://www.google.com")
         ]

--- a/tests/NavigationTests.elm
+++ b/tests/NavigationTests.elm
@@ -14,6 +14,7 @@ type Msg
     | Back Int
     | Forward Int
     | Load String
+    | Reload
 
 
 type alias Model =
@@ -50,6 +51,9 @@ programUpdate msg model =
 
         Load url ->
             ( model, Navigation.load url )
+
+        Reload ->
+            ( model, Navigation.reload )
 
 
 sampleProgram : TestContext Model Msg
@@ -111,6 +115,11 @@ all =
                 sampleProgram
                     |> update (Load "/foo")
                     |> expectHref "https://elm.testable/foo"
+        , test "refresh does nothing" <|
+            \() ->
+                sampleProgram
+                    |> update Reload
+                    |> done
         , describe "navigation simulation"
             [ test "simulates navigation for testing" <|
                 \() ->

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -1,8 +1,19 @@
 module Testable.NavigationTests exposing (..)
 
 import Expect
+import Navigation
 import Test exposing (..)
 import Testable.Navigation exposing (..)
+
+
+initialLocation : Navigation.Location
+initialLocation =
+    getLocation "https://elm.testable/"
+
+
+initWithLocation : History
+initWithLocation =
+    init (Just "https://elm.testable/")
 
 
 all : Test
@@ -94,7 +105,7 @@ all =
             [ describe "new url"
                 [ test "adds a new url to the history" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> Expect.equal
                                 ( ( 1
@@ -106,7 +117,7 @@ all =
                                 )
                 , test "erases forward history" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (New "/bar")
                             |> thenUpdate (Jump -2)
@@ -123,7 +134,7 @@ all =
             , describe "modify url"
                 [ test "modify current location in the history" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (Modify "/foo")
                             |> Expect.equal
                                 ( ( 0
@@ -134,7 +145,7 @@ all =
                                 )
                 , test "does not erase forward history" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (New "/bar")
                             |> thenUpdate (Jump -1)
@@ -150,7 +161,7 @@ all =
                                 )
                 , test "does not modify to the same url, preventing infinite loop" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (Modify "/foo")
                             |> Expect.equal
@@ -165,7 +176,7 @@ all =
             , describe "jump in history" <|
                 [ test "goes back, asking to trigger location msg" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (New "/bar")
                             |> thenUpdate (Jump -1)
@@ -180,7 +191,7 @@ all =
                                 )
                 , test "goes forward, asking to trigger location msg" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (New "/bar")
                             |> thenUpdate (Jump -2)
@@ -196,7 +207,7 @@ all =
                                 )
                 , test "has a limit to jumping back" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (Jump -100)
                             |> Expect.equal
@@ -209,7 +220,7 @@ all =
                                 )
                 , test "has a limit to jumping forward" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (New "/foo")
                             |> thenUpdate (Jump -1)
                             |> thenUpdate (Jump 100)
@@ -225,7 +236,7 @@ all =
             , describe "visit url"
                 [ test "visit adds a new url to the history, asking to trigger location msg" <|
                     \() ->
-                        init
+                        initWithLocation
                             |> update (Visit "/foo")
                             |> Expect.equal
                                 ( ( 1

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -25,6 +25,22 @@ all =
                             , username = ""
                             , password = ""
                             }
+            , test "parses a location without querystring correclty" <|
+                \() ->
+                    getLocation "https://elm.testable:3030/foo/bar#lorem"
+                        |> Expect.equal
+                            { href = "https://elm.testable:3030/foo/bar#lorem"
+                            , host = "elm.testable"
+                            , hostname = "elm.testable"
+                            , protocol = "https:"
+                            , origin = "https://elm.testable"
+                            , port_ = "3030"
+                            , pathname = "/foo/bar"
+                            , search = ""
+                            , hash = "#lorem"
+                            , username = ""
+                            , password = ""
+                            }
             ]
         , describe "setLocation"
             [ test "replaces the path when the requested url is a root path" <|
@@ -60,6 +76,13 @@ all =
                         |> setLocation "#qux"
                         |> .href
                         |> Expect.equal "https://elm.testable/foo?bar#qux"
+            , test "updates the hash without search in the middle" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "/foo#bar"
+                        |> setLocation "#qux"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo#qux"
             , test "updates the whole path" <|
                 \() ->
                     initialLocation

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -1,0 +1,70 @@
+module Testable.NavigationTests exposing (..)
+
+import Expect
+import Navigation
+import Test exposing (..)
+import Testable.Navigation exposing (..)
+
+
+initialLocation : Navigation.Location
+initialLocation =
+    getLocation "https://elm.testable/foo"
+
+
+all : Test
+all =
+    describe "Navigation"
+        [ describe "getLocation"
+            [ test "parses a location correclty" <|
+                \() ->
+                    getLocation "https://elm.testable:3030/foo/bar?baz=qux#lorem"
+                        |> Expect.equal
+                            { href = "https://elm.testable:3030/foo/bar?baz=qux#lorem"
+                            , host = "elm.testable"
+                            , hostname = "elm.testable"
+                            , protocol = "https:"
+                            , origin = "https://elm.testable"
+                            , port_ = "3030"
+                            , pathname = "/foo/bar"
+                            , search = "?baz=qux"
+                            , hash = "#lorem"
+                            , username = ""
+                            , password = ""
+                            }
+            ]
+        , describe "setLocation"
+            [ test "replaces the path when the requested url is a root path" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "/foo"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo"
+            , test "only changes the last part of the path when requesting a relative url" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "/foo/bar"
+                        |> setLocation "baz"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo/baz"
+            , test "updates the query string" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "/foo"
+                        |> setLocation "?q=bar"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo?q=bar"
+            , test "updates the hash" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "/foo?bar#baz"
+                        |> setLocation "#qux"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo?bar#qux"
+            , test "updates the whole path" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "http://www.google.com"
+                        |> .href
+                        |> Expect.equal "http://www.google.com"
+            ]
+        ]

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -125,6 +125,19 @@ all =
                                   )
                                 , ReturnLocation (getLocation "https://elm.testable/baz")
                                 )
+                , test "does not modify to the same url, preventing infinite loop" <|
+                    \() ->
+                        init
+                            |> update (New "/foo")
+                            |> thenUpdate (Modify "/foo")
+                            |> Expect.equal
+                                ( ( 1
+                                  , [ initialLocation
+                                    , getLocation "https://elm.testable/foo"
+                                    ]
+                                  )
+                                , NoOp
+                                )
                 ]
             , describe "jump in history" <|
                 [ test "goes back, asking to trigger location msg" <|

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -222,6 +222,20 @@ all =
                                 , TriggerLocationMsg (getLocation "https://elm.testable/foo")
                                 )
                 ]
+            , describe "visit url"
+                [ test "visit adds a new url to the history, asking to trigger location msg" <|
+                    \() ->
+                        init
+                            |> update (Visit "/foo")
+                            |> Expect.equal
+                                ( ( 1
+                                  , [ initialLocation
+                                    , getLocation "https://elm.testable/foo"
+                                    ]
+                                  )
+                                , TriggerLocationMsg (getLocation "https://elm.testable/foo")
+                                )
+                ]
             ]
         ]
 

--- a/tests/Testable/NavigationTests.elm
+++ b/tests/Testable/NavigationTests.elm
@@ -8,7 +8,7 @@ import Testable.Navigation exposing (..)
 
 initialLocation : Navigation.Location
 initialLocation =
-    getLocation "https://elm.testable/foo"
+    getLocation "https://elm.testable"
 
 
 all : Test
@@ -46,6 +46,12 @@ all =
                         |> setLocation "baz"
                         |> .href
                         |> Expect.equal "https://elm.testable/foo/baz"
+            , test "change relative path as root for pathless href" <|
+                \() ->
+                    initialLocation
+                        |> setLocation "foo"
+                        |> .href
+                        |> Expect.equal "https://elm.testable/foo"
             , test "updates the query string" <|
                 \() ->
                     initialLocation

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -5,6 +5,7 @@ import FlagsTests
 import HttpTests
 import MockTaskTests
 import ModelTests
+import NavigationTests
 import PortCmdTests
 import PortSubTests
 import TaskTests
@@ -34,6 +35,7 @@ all =
         -- Domain-specific APIs
         , HttpTests.all
         , TimeTests.all
+        , NavigationTests.all
 
         -- TODO: Random
         -- TODO: Add Websocket tests (see examples/tests/WebsocketChatTests)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,6 +10,7 @@ import PortCmdTests
 import PortSubTests
 import TaskTests
 import Test exposing (..)
+import Testable.NavigationTests
 import Testable.TaskTests
 import TimeTests
 import ViewTests
@@ -36,6 +37,7 @@ all =
         , HttpTests.all
         , TimeTests.all
         , NavigationTests.all
+        , Testable.NavigationTests.all
 
         -- TODO: Random
         -- TODO: Add Websocket tests (see examples/tests/WebsocketChatTests)

--- a/tests/ViewTests.elm
+++ b/tests/ViewTests.elm
@@ -4,7 +4,7 @@ import Expect
 import Html
 import Html.Events exposing (onClick)
 import Test exposing (..)
-import Test.Html.Events as Events
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 import TestContext exposing (TestContext)
@@ -57,18 +57,18 @@ all =
         , test "triggers events" <|
             \() ->
                 htmlProgram
-                    |> TestContext.simulate (Query.find [ Selector.tag "button" ]) Events.Click
+                    |> TestContext.simulate (Query.find [ Selector.tag "button" ]) Event.click
                     |> TestContext.expectView
                     |> Query.has [ Selector.tag "p" ]
         , test "fails when triggering events on a not found element" <|
             \() ->
                 htmlProgram
-                    |> TestContext.simulate (Query.find [ Selector.tag "foo" ]) Events.Click
+                    |> TestContext.simulate (Query.find [ Selector.tag "foo" ]) Event.click
                     |> expectError "expects to find 1 element, but it found 0 instead."
         , test "fails when triggersingevents on an element that does not handle that event" <|
             \() ->
                 htmlProgram
-                    |> TestContext.simulate (Query.find [ Selector.tag "button" ]) Events.DoubleClick
+                    |> TestContext.simulate (Query.find [ Selector.tag "button" ]) Event.doubleClick
                     |> Expect.all
                         [ expectError "The event"
                         , expectError "does not exist on the found node."

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Sample Elm Test",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/xavh4/elm-testable.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         ".",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,7 @@
     "native-modules": true,
     "dependencies": {
         "avh4/elm-fifo": "1.0.3 <= v < 2.0.0",
-        "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
+        "eeue56/elm-html-test": "4.1.0 <= v < 5.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-community/list-extra": "6.1.0 <= v < 7.0.0",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Sample Elm Test",
-    "repository": "https://github.com/xavh4/elm-testable.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         ".",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -14,6 +14,7 @@
         "eeue56/elm-html-test": "3.1.1 <= v < 4.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },


### PR DESCRIPTION
Hello,

I really want to use this, so I'm trying to make the necessaries changes to make it usable at least with elm-github-install. I've added documentation, which I believe we can improve later with code examples, and renamed `_user$project` to `_xavh$elm-testable`.

The reason to use `xavh` and not `avh` is because the native modules are loaded in alphabetical order, so "avh" was causing everything to fail.

It would be much better if we could not depend on loading order, with a solution like this: https://github.com/elm-community/webgl/pull/14/files

But idk if this will work for elm-testable, what do you think? Any ideas?